### PR TITLE
Zap register variables and R0-31, zap/preserve entire ranges, global zap/preserve

### DIFF
--- a/lua/wire/client/hlzasm/hc_codetree.lua
+++ b/lua/wire/client/hlzasm/hc_codetree.lua
@@ -90,7 +90,11 @@ end
 -- Returns free (non-busy) register. Does not check EBP and ESP
 function HCOMP:FreeRegister()
   -- Try to find a free register
-  for i=1,6 do
+  for i=1,#self.RegisterBusy do
+    if not self.RegisterBusy[i] then return i end
+  end
+
+    for i=1,6 do
     if not self.RegisterBusy[i] then return i end
   end
 

--- a/lua/wire/client/hlzasm/hc_codetree.lua
+++ b/lua/wire/client/hlzasm/hc_codetree.lua
@@ -94,10 +94,6 @@ function HCOMP:FreeRegister()
     if not self.RegisterBusy[i] then return i end
   end
 
-    for i=1,6 do
-    if not self.RegisterBusy[i] then return i end
-  end
-
   -- Try to find a register that wasnt pushed to stack yet
 --  for i=1,6 do
 --    if not self.RegisterStackOffset[i] then

--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -206,6 +206,8 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
   self.Settings.GenerateComments = true -- Generates comments in output listing
 
   -- Code generation settings
+  self.Settings.AutoBusyRegisters = false -- Automatically preserves or zaps a range of registers for all code leaves that are generated while this is enabled.
+  self.Settings.AutoBusyRegisterRanges = {}
   self.Settings.FixedSizeOutput = false -- Output fixed-size instructions
   self.Settings.SeparateDataSegment = false -- Puts all variables into separate data segment
   self.Settings.GenerateLibrary = false -- Generate precompiled library

--- a/lua/wire/client/hlzasm/hc_expression.lua
+++ b/lua/wire/client/hlzasm/hc_expression.lua
@@ -45,10 +45,8 @@ function HCOMP:Expression_ExplictIncDec(opcode,label,returnAfter)
     elseif label.Type == "Stack" then
       operationLeaf.Operands[1] = { Stack = label.StackOffset }
     elseif label.Type == "Register" then
-      if self.RegisterIdentities[label.Name] ~= nil then 
-        if self.RegisterIdentities[label.Name] == -1 then
-          self:Error("Attempting to use register variable after zapping it")
-        end
+      if self.RegisterIdentities[label.Name] == -1 then
+        self:Error("Attempting to use register variable after zapping it")
       end
       operationLeaf.Operands[1] = { Register = label.Value }
     end
@@ -198,10 +196,8 @@ function HCOMP:Expression_ArrayAccess(label) local TOKEN = self.TOKEN
       addressLeaf.Operands[2] = { Constant = {{ Type = TOKEN.IDENT, Data = label.Name, Position = self:CurrentSourcePosition() }} }
       operationLeaf = { MemoryPointer = addressLeaf }
     elseif label.Type == "Register" then
-      if self.RegisterIdentities[label.Name] ~= nil then 
-        if self.RegisterIdentities[label.Name] == -1 then
-          self:Error("Attempting to use register variable after zapping it")
-        end
+      if self.RegisterIdentities[label.Name] == -1 then
+        self:Error("Attempting to use register variable after zapping it")
       end
       addressLeaf.Opcode = "add"
       addressLeaf.Operands[1] = arrayOffsetLeaf
@@ -399,10 +395,8 @@ function HCOMP:Expression_Level3() local TOKEN = self.TOKEN
         end
       elseif label.Type == "Register" then
         -- Register variable
-        if self.RegisterIdentities[label.Name] ~= nil then 
-          if self.RegisterIdentities[label.Name] == -1 then
-            self:Error("Attempting to use register variable after zapping it")
-          end
+        if self.RegisterIdentities[label.Name] == -1 then
+          self:Error("Attempting to use register variable after zapping it")
         end
         operationLeaf = { Register = label.Value }
       end
@@ -670,10 +664,8 @@ function HCOMP:ConstantExpression_Level3()
         -- Pointer to stack value is not a constant
         return false
       elseif label.Type == "Register" then
-        if self.RegisterIdentities[label.Name] ~= nil then 
-          if self.RegisterIdentities[label.Name] == -1 then
-            self:Error("Attempting to use register variable after zapping it")
-          end
+        if self.RegisterIdentities[label.Name] == -1 then
+          self:Error("Attempting to use register variable after zapping it")
         end
         -- Register variable is not a constant
         return false
@@ -756,10 +748,8 @@ function HCOMP:ConstantExpression_Level3()
       -- Stack variables are not constant
       return false
     elseif label.Type == "Register" then
-      if self.RegisterIdentities[label.Name] ~= nil then 
-        if self.RegisterIdentities[label.Name] == -1 then
-          self:Error("Attempting to use register variable after zapping it")
-        end
+      if self.RegisterIdentities[label.Name] == -1 then
+        self:Error("Attempting to use register variable after zapping it")
       end
       -- Register variable is not a constant
       return false

--- a/lua/wire/client/hlzasm/hc_expression.lua
+++ b/lua/wire/client/hlzasm/hc_expression.lua
@@ -45,6 +45,11 @@ function HCOMP:Expression_ExplictIncDec(opcode,label,returnAfter)
     elseif label.Type == "Stack" then
       operationLeaf.Operands[1] = { Stack = label.StackOffset }
     elseif label.Type == "Register" then
+      if self.RegisterIdentities[label.Name] ~= nil then 
+        if self.RegisterIdentities[label.Name] == -1 then
+          self:Error("Attempting to use register variable after zapping it")
+        end
+      end
       operationLeaf.Operands[1] = { Register = label.Value }
     end
   end
@@ -193,6 +198,11 @@ function HCOMP:Expression_ArrayAccess(label) local TOKEN = self.TOKEN
       addressLeaf.Operands[2] = { Constant = {{ Type = TOKEN.IDENT, Data = label.Name, Position = self:CurrentSourcePosition() }} }
       operationLeaf = { MemoryPointer = addressLeaf }
     elseif label.Type == "Register" then
+      if self.RegisterIdentities[label.Name] ~= nil then 
+        if self.RegisterIdentities[label.Name] == -1 then
+          self:Error("Attempting to use register variable after zapping it")
+        end
+      end
       addressLeaf.Opcode = "add"
       addressLeaf.Operands[1] = arrayOffsetLeaf
       addressLeaf.Operands[2] = { Register = label.Value }
@@ -389,6 +399,11 @@ function HCOMP:Expression_Level3() local TOKEN = self.TOKEN
         end
       elseif label.Type == "Register" then
         -- Register variable
+        if self.RegisterIdentities[label.Name] ~= nil then 
+          if self.RegisterIdentities[label.Name] == -1 then
+            self:Error("Attempting to use register variable after zapping it")
+          end
+        end
         operationLeaf = { Register = label.Value }
       end
     end
@@ -655,6 +670,11 @@ function HCOMP:ConstantExpression_Level3()
         -- Pointer to stack value is not a constant
         return false
       elseif label.Type == "Register" then
+        if self.RegisterIdentities[label.Name] ~= nil then 
+          if self.RegisterIdentities[label.Name] == -1 then
+            self:Error("Attempting to use register variable after zapping it")
+          end
+        end
         -- Register variable is not a constant
         return false
       elseif label.Type == "Unknown" then
@@ -736,6 +756,11 @@ function HCOMP:ConstantExpression_Level3()
       -- Stack variables are not constant
       return false
     elseif label.Type == "Register" then
+      if self.RegisterIdentities[label.Name] ~= nil then 
+        if self.RegisterIdentities[label.Name] == -1 then
+          self:Error("Attempting to use register variable after zapping it")
+        end
+      end
       -- Register variable is not a constant
       return false
     elseif label.Type == "Unknown" then

--- a/lua/wire/client/hlzasm/hc_output.lua
+++ b/lua/wire/client/hlzasm/hc_output.lua
@@ -296,7 +296,7 @@ RegisterName[22] = "KS"
 RegisterName[23] = "LS"
 for port=0,1023 do RegisterName[1024+port] = "port"..port end
 for reg=0,31 do RegisterName[96+reg] = "R"..reg end
-
+HCOMP.RegisterName = RegisterName
 
 local SegmentRegisterName = {}
 SegmentRegisterName[01] = "CS"
@@ -316,7 +316,7 @@ SegmentRegisterName[14] = "EDI"
 SegmentRegisterName[15] = "ESP"
 SegmentRegisterName[16] = "EBP"
 for reg=0,31 do SegmentRegisterName[17+reg] = "R"..reg end
-
+HCOMP.SegmentRegisterName = RegisterName
 
 
 

--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -113,7 +113,7 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
       end
     end
       if StartInd ~= -1 and EndInd ~= -1 then
-        table.insert(self.Settings.AutoPreserveRegisterRanges,{StartInd,EndInd})
+        table.insert(self.Settings.AutoBusyRegisterRanges,{true,StartInd,EndInd})
       else
         self:Error(StartRegister .. " to " .. EndRegister .. " is an invalid range!",
         macroPosition.Line,macroPosition.Col,macroPosition.File)

--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -70,6 +70,54 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
       CPULib.CPUName = pragmaCommand
     elseif pragmaName == "searchpath" then
       table.insert(self.SearchPaths,pragmaCommand)
+    elseif pragmaName == "allow" or pragmaName == "zap" then
+    if not self.Settings.AutoBusyRegisters then
+      self.Settings.AutoBusyRegisters = true
+    end
+    local Arguments = string.gmatch(macroParameters,'[^, ]+') -- comma separate the two registers
+    Arguments() -- drop first space
+    local StartRegister = trimString(Arguments())
+    local EndRegister = trimString(Arguments())
+    local StartInd,EndInd = -1,-1
+    for ind,reg in ipairs(self.RegisterName) do
+      if reg == StartRegister then
+        StartInd = ind
+      end
+      if reg == EndRegister then
+        EndInd = ind
+        break
+      end
+    end
+    if StartInd ~= -1 and EndInd ~= -1 then
+      table.insert(self.Settings.AutoBusyRegisterRanges,{false,StartInd,EndInd})
+    else
+      self:Error(StartRegister .. " to " .. EndRegister .. " is an invalid range!",
+      macroPosition.Line,macroPosition.Col,macroPosition.File)
+    end
+    elseif pragmaName == "disallow" or pragmaName == "preserve" then
+    if not self.Settings.AutoBusyRegisters then
+      self.Settings.AutoBusyRegisters = true
+    end
+    local Arguments = string.gmatch(macroParameters,'[^, ]+') -- comma separate the two registers
+    Arguments() -- drop first space
+    local StartRegister = trimString(Arguments())
+    local EndRegister = trimString(Arguments())
+    local StartInd,EndInd = -1,-1
+    for ind,reg in ipairs(self.RegisterName) do
+      if reg == StartRegister then
+        StartInd = ind
+      end
+      if reg == EndRegister then
+        EndInd = ind
+        break
+      end
+    end
+      if StartInd ~= -1 and EndInd ~= -1 then
+        table.insert(self.Settings.AutoPreserveRegisterRanges,{StartInd,EndInd})
+      else
+        self:Error(StartRegister .. " to " .. EndRegister .. " is an invalid range!",
+        macroPosition.Line,macroPosition.Col,macroPosition.File)
+      end
     end
   elseif macroName == "define" then -- #define
     local defineName = trimString(string.sub(macroParameters,1,(string.find(macroParameters," ") or 0)-1))

--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -74,10 +74,11 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
     if not self.Settings.AutoBusyRegisters then
       self.Settings.AutoBusyRegisters = true
     end
-    local Arguments = string.gmatch(macroParameters,'[^, ]+') -- comma separate the two registers
-    Arguments() -- drop first space
-    local StartRegister = trimString(Arguments())
-    local EndRegister = trimString(Arguments())
+    local StartRegister, EndRegister = string.match(macroParameters, "([^,%s]+)%s*,%s*([^,%s]+)")
+    if StartRegister == nil then
+      self:Error("Missing register range argument",
+      macroPosition.Line,macroPosition.Col,macroPosition.File)
+    end
     local StartInd,EndInd = -1,-1
     for ind,reg in ipairs(self.RegisterName) do
       if reg == StartRegister then
@@ -98,10 +99,11 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
     if not self.Settings.AutoBusyRegisters then
       self.Settings.AutoBusyRegisters = true
     end
-    local Arguments = string.gmatch(macroParameters,'[^, ]+') -- comma separate the two registers
-    Arguments() -- drop first space
-    local StartRegister = trimString(Arguments())
-    local EndRegister = trimString(Arguments())
+    local StartRegister, EndRegister = string.match(macroParameters, "([^,%s]+)%s*,%s*([^,%s]+)")
+    if StartRegister == nil then
+      self:Error("Missing register range argument",
+      macroPosition.Line,macroPosition.Col,macroPosition.File)
+    end
     local StartInd,EndInd = -1,-1
     for ind,reg in ipairs(self.RegisterName) do
       if reg == StartRegister then


### PR DESCRIPTION
Solves #9

Changes can be separated if desired by maintainers.

NOTE this does NOT affect default behavior, all registers past EDI default to busy so code generation WILL NOT BE AFFECTED unless you EXPLICITLY USE THESE FEATURES, thank you.

All features are showcased & tested in this code snippet
![image](https://github.com/wiremod/wire-cpu/assets/57756830/1e09fc78-c075-4f03-8cfb-34512db2f6d4)
(generated code)
![image](https://github.com/wiremod/wire-cpu/assets/57756830/c5a4ba6c-4487-474f-b97c-a47852104617)

### Zapping register variables
Register variables can now be zapped, this will free the register and gives an error message if the variable is referenced on later lines in the function
example of said errors:
![image](https://github.com/wiremod/wire-cpu/assets/57756830/88ad9fd4-fc6f-4984-b1ed-9fa93f9d3de3)

### Pragma zap(or allow)/preserve(or disallow)
Changes the default state of the compiler to have the range between the two registers all zapped or preserved by default on all leaves, each preserve/zap is processed in order, for example:
`#pragma preserve EAX,EBP`
`#pragma zap EBX,EDX`
will leave EBX,ECX,EDX zapped but the others in the range of EAX,EBP remain preserved

### Expanded busy register list
Now capable of containing all of the cpu's registers, this allows you to zap R0-R31 to use with the expression generator and high level code

### Zapping/Preserving ranges
You can now zap or preserve an entire range of registers without having to specify all of the registers in the middle by putting a - between the first and second register, for example
`ZAP EBX-EDX` will zap EBX, ECX, and EDX