### PR TITLE
Carry segments over during complex memory access expressions

### DIFF
--- a/lua/wire/client/hlzasm/hc_codetree.lua
+++ b/lua/wire/client/hlzasm/hc_codetree.lua
@@ -190,7 +190,7 @@ end
 function HCOMP:ReadOperandFromMemory(operands,index)
   if operands[index].MemoryPointer.Opcode then -- Parse complex expression
     local addrReg,isTemp = self:GenerateLeaf(operands[index].MemoryPointer,true)
-    operands[index] = { MemoryRegister = addrReg, Temporary = isTemp }
+    operands[index] = { MemoryRegister = addrReg, Segment = operands[index].Segment, Temporary = isTemp }
     self.RegisterBusy[addrReg] = isTemp
     return addrReg
   else -- Parse an operand
@@ -202,8 +202,7 @@ function HCOMP:ReadOperandFromMemory(operands,index)
       rstackLeaf.Operands[1] = { Register = freeReg }
       rstackLeaf.Operands[2] = { Constant = operands[index].MemoryPointer.Stack, Segment = 16 }
       self:GenerateLeaf(rstackLeaf)
-
-      operands[index] = { MemoryRegister = freeReg, Temporary = true }
+      operands[index] = { MemoryRegister = freeReg, Segment = operands[index].Segment, Temporary = true }
       self.RegisterBusy[freeReg] = true
       return addrReg
     else -- Generate more than just a stack read


### PR DESCRIPTION
Solves #10

Could use a more thorough look by someone with more time but as far as my tests indicate, this solves the issue with no side effects

Original Code:
![image](https://github.com/wiremod/wire-cpu/assets/57756830/8be9bc5b-84c0-479f-8df2-d352137bdf3e)

Before fix:
![279844664-b150f229-5139-4baf-b82d-46044c83725a](https://github.com/wiremod/wire-cpu/assets/57756830/22d7544e-242b-43b7-8f80-21630e4ff533)

After fix:
![image](https://github.com/wiremod/wire-cpu/assets/57756830/28d05c34-c87e-47d2-abb7-fab5639793a1)

Extra example:
![image](https://github.com/wiremod/wire-cpu/assets/57756830/58c032bb-c422-4e66-9bf9-826aa3745310)
![image](https://github.com/wiremod/wire-cpu/assets/57756830/9201cb36-8894-4121-bfea-829c14962426)