### PR TITLE
Instructions for setting the cpu error or clearing it in programs

### DIFF
--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -1000,6 +1000,8 @@ CPU(137, "EXTRETP",       1,  10.00,    R0,        "PTBL",  "",      "Set PTBL, 
 CPU(140, "EXTRETA",       0,  11.00,    R0,        "",      "",      "Return from an external interrupt and restore R0-R31 registers")
 CPU(141, "EXTRETPA",      1,  11.00,    R0,        "PTBL",  "",      "Set PTBL, then return from an external interrupt with restoring R0-R31 registers")
 ---- Dec 15 -- UNDEFINED ------------------------------------------------------------------------------------------------------------------------
+CPU(150, "ERR",           2,   3.00,    R0,        "X",  "Y",        "Output an external error where X is error number and Y is error parameter")
+CPU(151, "CLERR",         0,   1.00,    R0,        "",    "",        "Clear the external error output")
 ---- Dec 16 -- UNDEFINED ------------------------------------------------------------------------------------------------------------------------
 ---- Dec 17 -- UNDEFINED ------------------------------------------------------------------------------------------------------------------------
 ---- Dec 18 -- UNDEFINED ------------------------------------------------------------------------------------------------------------------------

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -1000,7 +1000,7 @@ CPU(137, "EXTRETP",       1,  10.00,    R0,        "PTBL",  "",      "Set PTBL, 
 CPU(140, "EXTRETA",       0,  11.00,    R0,        "",      "",      "Return from an external interrupt and restore R0-R31 registers")
 CPU(141, "EXTRETPA",      1,  11.00,    R0,        "PTBL",  "",      "Set PTBL, then return from an external interrupt with restoring R0-R31 registers")
 ---- Dec 15 -- UNDEFINED ------------------------------------------------------------------------------------------------------------------------
-CPU(150, "ERR",           2,   3.00,    R0,        "X",  "Y",        "Output an external error where X is error number and Y is error parameter")
+CPU(150, "STERR",         2,   3.00,    R0,        "X",  "Y",        "Output an external error where X is error number and Y is error parameter")
 CPU(151, "CLERR",         0,   1.00,    R0,        "",    "",        "Clear the external error output")
 ---- Dec 16 -- UNDEFINED ------------------------------------------------------------------------------------------------------------------------
 ---- Dec 17 -- UNDEFINED ------------------------------------------------------------------------------------------------------------------------

--- a/lua/wire/zvm/zvm_features.lua
+++ b/lua/wire/zvm/zvm_features.lua
@@ -645,7 +645,9 @@ function ZVM:ExternalInterrupt(interruptNo)
 end
 
 
-
+function ZVM:MakeErrorCode(Code) 
+  return Code * (10^math.floor(-math.log10(math.abs(Code)+1e-12)-1))
+end
 
 --------------------------------------------------------------------------------
 function ZVM:Interrupt(interruptNo,interruptParameter,isExternal,cascadeInterrupt)
@@ -660,7 +662,7 @@ function ZVM:Interrupt(interruptNo,interruptParameter,isExternal,cascadeInterrup
   self.LADD = interruptParameter or self.XEIP
 
   -- Output an error externally
-  local fractionalParameter = self.LADD * (10^math.floor(-math.log10(math.abs(self.LADD)+1e-12)-1))
+  local fractionalParameter = self:MakeErrorCode(self.LADD)
   self:SignalError(fractionalParameter+interruptNo)
 
   -- Check if interrupts handling is enabled

--- a/lua/wire/zvm/zvm_features.lua
+++ b/lua/wire/zvm/zvm_features.lua
@@ -645,8 +645,8 @@ function ZVM:ExternalInterrupt(interruptNo)
 end
 
 
-function ZVM:MakeErrorCode(Code) 
-  return Code * (10^math.floor(-math.log10(math.abs(Code)+1e-12)-1))
+function ZVM:MakeErrorCode(code,param) 
+  return code+(param * (10^math.floor(-math.log10(math.abs(param)+1e-12)-1)))
 end
 
 --------------------------------------------------------------------------------
@@ -662,8 +662,7 @@ function ZVM:Interrupt(interruptNo,interruptParameter,isExternal,cascadeInterrup
   self.LADD = interruptParameter or self.XEIP
 
   -- Output an error externally
-  local fractionalParameter = self:MakeErrorCode(self.LADD)
-  self:SignalError(fractionalParameter+interruptNo)
+  self:SignalError(self:MakeErrorCode(interruptNo,self.LADD))
 
   -- Check if interrupts handling is enabled
   if self.IF == 1 then

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -1222,8 +1222,7 @@ end
 
 
 ZVM.OpcodeTable[150] = function(self) -- STERR
-    self:Dyn_Emit("$L P = $2")
-    self:Dyn_Emit("P = P * (10^math.floor(-math.log10(math.abs(P)+1e-12)-1))")
+    self:Dyn_Emit("$L P = VM:MakeErrorCode($2)")
     self:Dyn_Emit("VM:SignalError(math.floor($1)+P)")
 end
 

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -1221,6 +1221,16 @@ ZVM.OpcodeTable[141] = function(self) --EXTRETPA
 end
 
 
+ZVM.OpcodeTable[150] = function(self) -- ERR
+    self:Dyn_Emit("$L P = $2")
+    self:Dyn_Emit("P = P * (10^math.floor(-math.log10(math.abs(P)+1e-12)-1))")
+    self:Dyn_Emit("VM:SignalError($1+P)")
+end
+
+ZVM.OpcodeTable[151] = function(self) -- CLERR
+    self:Dyn_Emit("VM:SignalError(0)")
+end
+
 --------------------------------------------------------------------------------
 ZVM.OpcodeTable[250] = function(self)  --VADD
   self:Dyn_Emit("if VM.VMODE == 2 then")

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -1222,8 +1222,7 @@ end
 
 
 ZVM.OpcodeTable[150] = function(self) -- STERR
-    self:Dyn_Emit("$L P = VM:MakeErrorCode($2)")
-    self:Dyn_Emit("VM:SignalError(math.floor($1)+P)")
+    self:Dyn_Emit("VM:SignalError(VM:MakeErrorCode($1,$2))")
 end
 
 ZVM.OpcodeTable[151] = function(self) -- CLERR

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -1221,10 +1221,10 @@ ZVM.OpcodeTable[141] = function(self) --EXTRETPA
 end
 
 
-ZVM.OpcodeTable[150] = function(self) -- ERR
+ZVM.OpcodeTable[150] = function(self) -- STERR
     self:Dyn_Emit("$L P = $2")
     self:Dyn_Emit("P = P * (10^math.floor(-math.log10(math.abs(P)+1e-12)-1))")
-    self:Dyn_Emit("VM:SignalError($1+P)")
+    self:Dyn_Emit("VM:SignalError(math.floor($1)+P)")
 end
 
 ZVM.OpcodeTable[151] = function(self) -- CLERR


### PR DESCRIPTION
Adds two new instructions

STERR (X),(Y) and CLERR

STERR(opcode 150) sets the CPU error output in a similar manner to actual errors, where X is the error code(equivalent to LINT) and Y is the error parameter(equivalent to LADD), but doesn't trigger an interrupt or set LINT/LADD on use, for example:
`STERR 1,65536` would display 1.065536 as the error from the CPU

CLERR(opcode 151) sets the CPU error to 0 without resetting the actual CPU, but doesn't change the LINT/LADD registers internally(they can be changed via CPUSET anyway)

This is primarily aimed at users who want to display custom error codes, or those who would like to clear the error from the CPU on successfully handled errors/interrupts, like the ones that may frequently occur through hardware signalling with external interrupts.