### PR TITLE
Failed ifdefs now stop processing macros inside of them

### DIFF
--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -213,6 +213,8 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
   self.Settings.NoUnreferencedLeaves = false -- Dont generate functions, variables that are not referenced
   self.Settings.DataSegmentOffset = 0 -- Data segment offset for separate data segment
 
+  self.Settings.NewIfDefs = true -- Changes ifdef handling to skip all tokens inside until endif
+
   -- Search paths
   self.SearchPaths = {
     "lib",
@@ -247,6 +249,8 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
   self.Defines["__LINE__"] = 0
   self.Defines["__FILE__"] = ""
   self.IFDEFLevel = {}
+  self.SkipToEndIf = false
+  self.EndIfsToSkip = 0
 
   -- Output text
   self.OutputText = {}

--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -36,6 +36,44 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
   local macroName = trimString(string.sub(macroLine,2,macroNameEnd-1))
   local macroParameters = trimString(string.sub(macroLine,macroNameEnd+1))
 
+  -- Stop parsing macros inside of a failed ifdef/ifndef
+  if self.SkipToEndIf then
+    if macroName == "endif" or macroName == "else" then
+      if self.EndIfsToSkip > 0 then 
+        self.EndIfsToSkip = self.EndIfsToSkip - 1
+      else
+        self.SkipToEndIf = false
+        return self:ParsePreprocessMacro(lineText,macroPosition) -- Rerun function to parse endif/else correctly
+      end
+    end
+    if macroName == "ifdef" or macroName == "ifndef" then
+    self.EndIfsToSkip = self.EndIfsToSkip + 1
+    end
+    self:Warning("skipping to next macro after checking "..macroName)
+    local InComment = false
+    for i = 0, 1024 do
+      if self:getChar() == '/' and not InComment then
+        self:nextChar()
+        if self:getChar() == '*' then
+        self:nextChar()
+        InComment = true
+        end
+      if self:getChar() == '*' then
+        self:nextChar()
+        if self:getChar() == '/' then
+          InComment = false
+        end
+      end
+      end
+      if (self.Code[1].Col == 1) and (self:getChar() == "#") and not InComment then
+      self.Code[1].NextCharPos = self.Code[1].NextCharPos - 1 -- Exit to let tokenizer handle from here
+      break
+      end
+      self:nextChar()
+    end
+    return
+  end
+
   if macroName == "pragma" then
     local pragmaName = string.lower(trimString(string.sub(macroParameters,1,(string.find(macroParameters," ") or 0)-1)))
     local pragmaCommand = trimString(string.sub(macroParameters,(string.find(macroParameters," ") or 0)+1))
@@ -91,6 +129,10 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
     if self.Defines[defineName] then
       self.IFDEFLevel[#self.IFDEFLevel+1] = false
     else
+      if self.Settings.NewIfDefs then
+        self.SkipToEndIf = true
+        self.EndIfsToSkip = 0
+      end
       self.IFDEFLevel[#self.IFDEFLevel+1] = true
     end
   elseif macroName == "ifndef" then -- #ifndef
@@ -98,6 +140,10 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
     if not self.Defines[defineName] then
       self.IFDEFLevel[#self.IFDEFLevel+1] = false
     else
+      if self.Settings.NewIfDefs then
+        self.SkipToEndIf = true
+        self.EndIfsToSkip = 0
+      end
       self.IFDEFLevel[#self.IFDEFLevel+1] = true
     end
   elseif macroName == "else" then -- #else

--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -47,27 +47,29 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
       end
     end
     if macroName == "ifdef" or macroName == "ifndef" then
-    self.EndIfsToSkip = self.EndIfsToSkip + 1
+      self.EndIfsToSkip = self.EndIfsToSkip + 1
     end
     self:Warning("skipping to next macro after checking "..macroName)
     local InComment = false
-    for i = 0, 1024 do
+    -- If this while loop hits end of file before #endif it won't produce an error, seems like the original behavior for ifdefs
+    while self:getChar() ~= "" do
       if self:getChar() == '/' and not InComment then
         self:nextChar()
         if self:getChar() == '*' then
-        self:nextChar()
-        InComment = true
+          self:nextChar()
+          InComment = true
         end
       if self:getChar() == '*' then
         self:nextChar()
         if self:getChar() == '/' then
+          self:nextChar()
           InComment = false
         end
       end
       end
       if (self.Code[1].Col == 1) and (self:getChar() == "#") and not InComment then
-      self.Code[1].NextCharPos = self.Code[1].NextCharPos - 1 -- Exit to let tokenizer handle from here
-      break
+        self.Code[1].NextCharPos = self.Code[1].NextCharPos - 1 -- Exit to let tokenizer handle from here
+        break
       end
       self:nextChar()
     end

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -577,10 +577,12 @@ end
 
 -- Returns current position in source file
 function HCOMP:CurrentSourcePosition()
-  if self.CurrentToken ~= nil then
+  if self.CurrentToken then
     if self.Tokens[self.CurrentToken-1] then
       return self.Tokens[self.CurrentToken-1].Position
     end
+  elseif self.FileName then
+      return { Line = 1, Col = 1, File = self.FileName}
   end
-    return { Line = 1, Col = 1, File = "HL-ZASM"}
+  return { Line = 1, Col = 1, File = "HL-ZASM"}
 end

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -577,9 +577,10 @@ end
 
 -- Returns current position in source file
 function HCOMP:CurrentSourcePosition()
-  if self.Tokens[self.CurrentToken-1] then
-    return self.Tokens[self.CurrentToken-1].Position
-  else
-    return { Line = 1, Col = 1, File = "HL-ZASM" }
+  if self.CurrentToken ~= nil then
+    if self.Tokens[self.CurrentToken-1] then
+      return self.Tokens[self.CurrentToken-1].Position
+    end
   end
+    return { Line = 1, Col = 1, File = "HL-ZASM"}
 end


### PR DESCRIPTION
Solves #8

Allows smarter preprocessing, including the branching of ifdefs and conditional pragmas/macros, not just conditional instructions, with the addition of a new pragma to turn this behavior on and off named **NewIfDefs**

**This will default to ON**, use `#pragma set NewIfDefs false` to turn it off if you still need the old behaviors to compile (if desired by maintainers and/or community this can be set to default OFF)

Example of skipping the `#ifdef y` that's in the failed `#ifdef x`, resulting in a size of 12 bytes for the compiled code
![code with new ifdef handling](https://github.com/wiremod/wire-cpu/assets/57756830/ddd7ae76-eafc-44e4-ab92-9e0f50a16176)

Note that the old version, would also parse the `#ifdef y` that's wrapped in `#ifdef x` even if `x` isn't defined, which accounts for the 2 byte size increase(to 14 bytes)
![code without new ifdef handling](https://github.com/wiremod/wire-cpu/assets/57756830/19767926-512e-44a0-adaa-e1a05a20fe6b)

Example w/ all tested cases for the result of the two numbers & the name of the CPU, which shows that the pragma commands get skipped too, unlike the old ifdef handling where no matter where a macro was it would still process regardless.
![the code with conditional pragmas](https://github.com/wiremod/wire-cpu/assets/57756830/29b43f5b-8d29-4b85-ba97-f466a9677ded)
![the cpu, showing "Test Y" as the result of conditional pragma](https://github.com/wiremod/wire-cpu/assets/57756830/6c6dbe07-78b9-48df-bce6-6118da8b8636)