### PR TITLE
Fixes Dereferencing ASM labels using the prefix * operator

### DIFF
--- a/lua/wire/client/hlzasm/hc_codetree.lua
+++ b/lua/wire/client/hlzasm/hc_codetree.lua
@@ -211,6 +211,13 @@ function HCOMP:ReadOperandFromMemory(operands,index)
         operands[index] = { MemoryRegister = operands[index].MemoryPointer.Register, Temporary = operands[index].MemoryPointer.Temporary }
         return operands[index].Register
       elseif operands[index].MemoryPointer.Constant then
+        -- Don't decay a label constant expression into an unusable memory address if possible
+        for _,item in pairs(operands[index].MemoryPointer.Constant) do
+          if item.Type == self.TOKEN.IDENT then
+            operands[index] = { MemoryPointer = operands[index].MemoryPointer.Constant }
+            return nil
+          end
+        end
         operands[index] = { Memory = operands[index].MemoryPointer.Constant }
         return nil
       else


### PR DESCRIPTION
Fixes #2

It still behaves a bit weirdly in my opinion (I haven't actually used this operator much) but this should make it stop converting label constants to nil valued and unnamed addresses for the *operator

Example showing its behavior, wrapping the label expression in parenthesis will modify the read position, where without parenthesis it will read the value at [label] and then modify the value in the temp register
![image](https://github.com/wiremod/wire-cpu/assets/57756830/33632d51-1d5d-4eda-b01c-1e92fce3f0b8)
