### PR TITLE
ZCPU Compile-time warnings can now be displayed in the editor + pragma for muting them

### DIFF
--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -93,7 +93,23 @@ end
 --
 -- Same rules for calling as for Error()
 function HCOMP:Warning(msg,param1,param2,param3)
-  print(self:formatPrefix(param1,param2,param3)..": Warning: "..msg)
+  local prefixstr,file,line,col = self:formatPrefix(param1,param2,param3)
+  local parent = self:CurrentSourcePosition().ParentFile
+  print(prefixstr..": Warning: "..msg) -- This is the original console print, we should only mute the editor warnings
+  if self.SilencedFiles[file] then
+    if self.SilencedFiles[file].Silenced or self.SilencedParents[parent] then
+      return
+    end
+  elseif self.SilencedParents[parent] then
+    return
+  end
+  local warning = {}
+  warning.trace = {start_line = line, start_col = col}
+  warning.message = msg
+  if file ~= self.FileName then -- self.FileName is the file that's open in the editor at the start of compile
+    warning.message = "(in file: '"..file.."') " .. warning.message
+  end
+  self.Warnings[#self.Warnings+1] = warning
 end
 
 
@@ -233,7 +249,9 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
   self.DebugInfo.Labels = {}
   self.DebugInfo.PositionByPointer = {}
   self.DebugInfo.PointersByLine = {}
-
+  self.Warnings = {} -- Warnings to pass to the editor
+  self.SilencedFiles = {} -- Will not push warnings from silenced files
+  self.SilencedParents = {} -- Includes from these files will get silenced
   -- Exported function list (library generation)
   self.ExportedSymbols = {}
   self.LabelLookup = {}
@@ -250,6 +268,7 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
 
   -- Output text
   self.OutputText = {}
+  return self.Warnings
 end
 
 

--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -58,7 +58,7 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
       local crtFilename = "lib\\"..string.lower(pragmaCommand).."\\init.txt"
       local fileText = self:LoadFile(crtFilename)
       if fileText then
-        table.insert(self.Code, 1, { Text = fileText, Line = 1, Col = 1, File = crtFilename, NextCharPos = 1 })
+        table.insert(self.Code, 1, { Text = fileText, Line = 1, Col = 1, File = crtFilename, ParentFile = macroPosition.File, NextCharPos = 1 })
       else
         self:Error("Unable to include CRT library "..pragmaCommand,
           macroPosition.Line,macroPosition.Col,macroPosition.File)
@@ -70,6 +70,12 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
       CPULib.CPUName = pragmaCommand
     elseif pragmaName == "searchpath" then
       table.insert(self.SearchPaths,pragmaCommand)
+    elseif pragmaName == "silence" or pragmaName == "mute" then
+        if pragmaCommand == "self" then
+          self.SilencedFiles[macroPosition.File] = { Silenced = true, FromParent = false }
+        elseif pragmaCommand == "includes" or pragmaCommand == "other" then
+          self.SilencedParents[macroPosition.File] = true
+      end
     end
   elseif macroName == "define" then -- #define
     local defineName = trimString(string.sub(macroParameters,1,(string.find(macroParameters," ") or 0)-1))
@@ -152,7 +158,7 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
 
     -- Push this file on top of the stack
     if fileText then
-      table.insert(self.Code, 1, { Text = fileText, Line = 1, Col = 1, File = fileName, NextCharPos = 1 })
+      table.insert(self.Code, 1, { Text = fileText, Line = 1, Col = 1, File = fileName, ParentFile = macroPosition.File, NextCharPos = 1 })
     else
       self:Error("Cannot open file: "..fileName,
         macroPosition.Line,macroPosition.Col,macroPosition.File)

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -231,7 +231,8 @@ function HCOMP:Tokenize() local TOKEN = self.TOKEN
   -- Read token position
   local tokenPosition = { Line = self.Code[1].Line,
                           Col  = self.Code[1].Col,
-                          File = self.Code[1].File }
+                          File = self.Code[1].File,
+                          ParentFile = self.Code[1].ParentFile }
 
   -- Check for end of file
   if self:getChar() == "" then
@@ -577,9 +578,12 @@ end
 
 -- Returns current position in source file
 function HCOMP:CurrentSourcePosition()
-  if self.Tokens[self.CurrentToken-1] then
-    return self.Tokens[self.CurrentToken-1].Position
-  else
-    return { Line = 1, Col = 1, File = "HL-ZASM" }
+  if self.CurrentToken then
+    if self.Tokens[self.CurrentToken-1] then
+      return self.Tokens[self.CurrentToken-1].Position
+    end
+  elseif self.FileName then
+      return { Line = 1, Col = 1, File = self.FileName, ParentFile = 'HL-ZASM'}
   end
+  return { Line = 1, Col = 1, File = "HL-ZASM", ParentFile = "HL-ZASM"}
 end

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -65,9 +65,9 @@ if CLIENT then
     CPULib.Debugger.PositionByPointer = {}
     CPULib.Debugger.PointersByLine = {}
     CPULib.CPUName = nil
+    CPULib.Warnings = HCOMP:StartCompile(source,fileName or "source",CPULib.OnWriteByte,nil)
 
     -- Start compiling the sourcecode
-    HCOMP:StartCompile(source,fileName or "source",CPULib.OnWriteByte,nil)
     HCOMP.Settings.CurrentPlatform = targetPlatform or "CPU"
     print("=== HL-ZASM High Level Assembly Compiler Output ==")
 
@@ -112,8 +112,12 @@ if CLIENT then
   -- Request validating the code
   function CPULib.Validate(editor,source,fileName)
     CPULib.Compile(source,fileName,
-      function()
+      function(warnings)
+        if #warnings > 0 then
+        editor.C.Val:Update(nil,warnings,"   "..#warnings.." Warnings, with "..(HCOMP.WritePointer or "?").." bytes compiled.", Color(163, 130, 64, 255))
+        else
         editor.C.Val:Update(nil, nil, "   Success, "..(HCOMP.WritePointer or "?").." bytes compiled.", Color(50, 128, 20))
+        end
       end,
       function(error,errorPos)
         local issue = (error or "unknown error")
@@ -163,7 +167,7 @@ if CLIENT then
           CPULib.Debugger.PositionByPointer = HCOMP.DebugInfo.PositionByPointer
           CPULib.Debugger.PointersByLine = HCOMP.DebugInfo.PointersByLine
 
-          CPULib.SuccessCallback()
+          CPULib.SuccessCallback(CPULib.Warnings)
         end
         timer.Remove("cpulib_compile")
         CPULib.Compiling = false


### PR DESCRIPTION
Quite frankly this was an overdue addition, as up to this point most users may not have ever known that warnings were in the console, this provides a quick and easy way to jump to said warnings, and makes the addition of new warnings more meaningful from here on out since everyone will see them(unless they use the handy dandy pragma commands I've added to silence them)

Displays filename for includes with warnings in them
![image](https://github.com/wiremod/wire-cpu/assets/57756830/8f58944b-5bb0-47ab-8b6c-d4713ca257f0)

Furthermore, included file warnings are accurate to where the warning is in the included file, though you can't automatically jump into the file by double clicking on external file warnings, you can jump to the line/col if you open the file manually
![image](https://github.com/wiremod/wire-cpu/assets/57756830/cfac01b3-4b9b-40a0-b3b5-7a3781e0c01c)

Additionally, you can silence editor warnings on a per-file basis using
`#pragma silence self` - Mutes warnings generated by code in this file
![selfmute](https://github.com/wiremod/wire-cpu/assets/57756830/be6ae2f4-c9c4-4712-82e2-f1cbb6704d0a)

`#pragma silence includes` - Mutes warnings generated by code in the files directly included by this file
![othermute](https://github.com/wiremod/wire-cpu/assets/57756830/395c26f0-8c24-45ea-8344-8553576f3e64)


Aliases for these pragma commands include
[silence, mute] for pragma name
[includes, other] for pragma parameter (to mute only warnings in any files included from this one)
[self] for pragma parameter (to mute only warnings in this file)