### PR TITLE
Removes failed ifdef "skipping to next macro" warning

### DIFF
--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -49,7 +49,6 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
     if macroName == "ifdef" or macroName == "ifndef" then
       self.EndIfsToSkip = self.EndIfsToSkip + 1
     end
-    self:Warning("skipping to next macro after checking "..macroName)
     local InComment = false
     -- If this while loop hits end of file before #endif it won't produce an error, seems like the original behavior for ifdefs
     while self:getChar() ~= "" do


### PR DESCRIPTION
I forgot to remove them, didn't realize they were still in until I tested #14 with #16 enabled at the same time.

Trying to give them a proper position(other than 1:1) results in wildly inaccurate line/col numbers, so I'm just removing the warn altogether because they're annoying (I would sincerely hope that users won't need these in the first place)