### PR TITLE
User defined macros w/ variables

### DIFF
--- a/lua/wire/client/hlzasm/hc_codetree.lua
+++ b/lua/wire/client/hlzasm/hc_codetree.lua
@@ -288,7 +288,14 @@ function HCOMP:GenerateLeaf(leaf,needResult)
       if istable(leaf.Constant) then
         self:Warning("Trying to generate invalid code ("..self:PrintTokens(leaf.Constant)..")",leaf)
       elseif not leaf.ForceTemporary then
-        self:Warning("Trying to generate invalid code",leaf)
+        if leaf.UnknownOperationByLabel then
+          -- Stop warning on macro use
+          if not string.match(leaf.UnknownOperationByLabel.Name,"/* MACRO") then
+            self:Warning("Trying to generate invalid code",leaf)
+          end
+        else
+          self:Warning("Trying to generate invalid code",leaf)
+        end
       end
     end
     return

--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -224,6 +224,7 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
   -- Code generation settings
   self.Settings.AutoBusyRegisters = false -- Automatically preserves or zaps a range of registers for all code leaves that are generated while this is enabled.
   self.Settings.AutoBusyRegisterRanges = {}
+  self.Settings.IncludeVectorMacros = {} -- Include macros for defining vector labels
   self.Settings.FixedSizeOutput = false -- Output fixed-size instructions
   self.Settings.SeparateDataSegment = false -- Puts all variables into separate data segment
   self.Settings.GenerateLibrary = false -- Generate precompiled library
@@ -266,9 +267,10 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
 
   -- All macros defined so far
   self.Defines = {}
-  self.Defines["__LINE__"] = 0
-  self.Defines["__FILE__"] = ""
+  self.Defines["__LINE__"] = {MacroValue = 0}
+  self.Defines["__FILE__"] = {MacroValue = ""}
   self.IFDEFLevel = {}
+  self.Macros = {}
   self.SkipToEndIf = false
   self.EndIfsToSkip = 0
 
@@ -316,6 +318,8 @@ function HCOMP:UnprotectedCompile()
       self.Code = nil
       self.SourceCode = nil
       self.Defines = nil
+      self.Macros = nil
+      self.ParsingMarco = nil
 
       -- Go to the first token
       self.CurrentToken = 1

--- a/lua/wire/client/hlzasm/hc_output.lua
+++ b/lua/wire/client/hlzasm/hc_output.lua
@@ -316,7 +316,7 @@ SegmentRegisterName[14] = "EDI"
 SegmentRegisterName[15] = "ESP"
 SegmentRegisterName[16] = "EBP"
 for reg=0,31 do SegmentRegisterName[17+reg] = "R"..reg end
-HCOMP.SegmentRegisterName = RegisterName
+HCOMP.SegmentRegisterName = SegmentRegisterName
 
 
 

--- a/lua/wire/client/hlzasm/hc_syntax.lua
+++ b/lua/wire/client/hlzasm/hc_syntax.lua
@@ -28,7 +28,7 @@ for i=0,15 do VectorSyntax.MATRIX[i+1] = {tostring(i)} end
 
 --------------------------------------------------------------------------------
 -- Compile an opcode (called after if self:MatchToken(TOKEN.OPCODE))
-function HCOMP:Opcode() local TOKEN,TOKENSET = self.TOKEN,self.TOKENSET
+function HCOMP:Opcode() local TOKEN = self.TOKEN
   local opcodeName = self.TokenData
   local opcodeNo = self.OpcodeNumber[self.TokenData]
   local operandCount = self.OperandCount[opcodeNo]
@@ -456,7 +456,7 @@ end
 
 --------------------------------------------------------------------------------
 -- Compile a variable/function. Returns corresponding labels
-function HCOMP:DefineVariable(isFunctionParam,isForwardDecl,isRegisterDecl,isStructMember) local TOKEN,TOKENSET = self.TOKEN,self.TOKENSET
+function HCOMP:DefineVariable(isFunctionParam,isForwardDecl,isRegisterDecl,isStructMember) local TOKEN = self.TOKEN
   local varType,varSize,isStruct
   if self:MatchToken(TOKEN.IDENT) then -- Define structure
     varType = self.TokenData
@@ -742,7 +742,7 @@ end
 
 --------------------------------------------------------------------------------
 -- Compile a single statement
-function HCOMP:Statement() local TOKEN,TOKENSET = self.TOKEN,self.TOKENSET
+function HCOMP:Statement() local TOKEN = self.TOKEN
   -- Parse code for absolute labels and define (LABEL:) 
   if self.CurrentToken == 1 then
 	while not(self:MatchToken(TOKEN.EOF)) do
@@ -826,13 +826,6 @@ function HCOMP:Statement() local TOKEN,TOKENSET = self.TOKEN,self.TOKENSET
     local tokenType = self.TokenType
     if self.BlockDepth > 0 then
       while self:MatchToken(TOKEN.REGISTER) or self:MatchToken(TOKEN.IDENT) do
-          -- Don't error on catching a variable being used near a zap/preserve
-          if self:MatchToken(TOKENSET.OPERATORS) then
-            -- move back 2 tokens and then re-parse this
-            self:PreviousToken()
-            self:PreviousToken()
-            return self:Statement()
-          end
         if self.TokenType == TOKEN.IDENT then
           if self.RegisterIdentities[self.TokenData] then
             if tokenType == TOKEN.PRESERVE then

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -114,6 +114,7 @@ end
 --------------------------------------------------------------------------------
 -- Generate table of all possible tokens
 HCOMP.TOKEN = {}
+HCOMP.TOKENSET = {} -- Manuallly defined sets of tokens
 HCOMP.TOKEN_NAME = {}
 HCOMP.TOKEN_NAME2 = {}
 local IDX = 1
@@ -127,6 +128,49 @@ for tokenName,tokenData in pairs(HCOMP.TOKEN_TEXT) do
   end
   IDX = IDX + 1
 end
+
+HCOMP.TOKENSET.OPERATORS = {
+  HCOMP.TOKEN.LPAREN,
+  HCOMP.TOKEN.RPAREN,
+  HCOMP.TOKEN.LSUBSCR,
+  HCOMP.TOKEN.RSUBSCR,
+  HCOMP.TOKEN.TIMES,
+  HCOMP.TOKEN.SLASH,
+  HCOMP.TOKEN.MODULUS,
+  HCOMP.TOKEN.PLUS,
+  HCOMP.TOKEN.MINUS,
+  HCOMP.TOKEN.AND,
+  HCOMP.TOKEN.OR,
+  HCOMP.TOKEN.XOR,
+  HCOMP.TOKEN.POWER,
+  HCOMP.TOKEN.INC,
+  HCOMP.TOKEN.DEC,
+  HCOMP.TOKEN.SHL,
+  HCOMP.TOKEN.SHR,
+  HCOMP.TOKEN.EQL,
+  HCOMP.TOKEN.NEQ,
+  HCOMP.TOKEN.LEQ,
+  HCOMP.TOKEN.LSS,
+  HCOMP.TOKEN.GEQ,
+  HCOMP.TOKEN.GTR,
+  HCOMP.TOKEN.NOT,
+  HCOMP.TOKEN.EQUAL,
+  HCOMP.TOKEN.LAND,
+  HCOMP.TOKEN.LOR,
+  HCOMP.TOKEN.EQLADD,
+  HCOMP.TOKEN.EQLSUB,
+  HCOMP.TOKEN.EQLMUL,
+  HCOMP.TOKEN.EQLDIV,
+  HCOMP.TOKEN.DOT
+}
+
+HCOMP.TOKENSET.ASSIGNMENT = {
+  HCOMP.TOKEN.EQUAL,
+  HCOMP.TOKEN.EQLADD,
+  HCOMP.TOKEN.EQLSUB,
+  HCOMP.TOKEN.EQLMUL,
+  HCOMP.TOKEN.EQLDIV
+}
 
 -- Create lookup tables for faster parsing
 HCOMP.PARSER_LOOKUP = {}
@@ -495,6 +539,14 @@ end
 
 -- Returns true and skips a token if it matches this one
 function HCOMP:MatchToken(tok)
+  if istable(tok) then -- Match against a table of tokens
+    for _,token in pairs(tok) do
+      if self:MatchToken(token) then
+        return true
+      end
+    end
+    return false
+  end
   if not self.Tokens[self.CurrentToken] then
     return tok == self.TOKEN.EOF
   end

--- a/lua/wire/client/text_editor/modes/zcpu.lua
+++ b/lua/wire/client/text_editor/modes/zcpu.lua
@@ -94,6 +94,7 @@ local macroTable = {
   ["ENDIF"] = true,
   ["ELSE"] = true,
   ["UNDEF"] = true,
+  ["MACRO"] = true,
 }
 
 function EDITOR:CommentSelection(removecomment)


### PR DESCRIPTION
Definition syntax:
`#macro (name) (number of arguments) (code using $(arg num) to refer to argument)\n`
Use syntax (once defined):
`(name) a, b, c`

Example code that recreates the compiler's own hardcoded vec2f macro
![gmod_5dGvGmP5ZQ](https://github.com/wiremod/wire-cpu/assets/57756830/ade603ff-4720-43e7-98ae-fe3eadc47bb2)

Generated code comparison
![gmod_NzyC7wUxl3](https://github.com/wiremod/wire-cpu/assets/57756830/08b74866-aafc-4fbc-a28b-bdc381ca5169)


Macros can be referenced by other macros, at nearly no slowdown to compile time (tested with a chain of 60 macros referencing the next macro, and 16 uses of 4 defined macros of varied size, all compiles were under 1s) **unless the macro is self-referencing infinitely, I can't seem to find a way to solve that one and am open to suggestions for solving before this is considered merge-worthy**

The plan was to replace the inbuilt vector types with an include to a file containing definitions that recreate their use, so you can replace their names with structs to use them in C-style syntax w/ variables, but eh, that can come later.