### PR TITLE
Correct INT Flag 8 to set page table entries to the correct value rather than 1

### DIFF
--- a/lua/wire/zvm/zvm_features.lua
+++ b/lua/wire/zvm/zvm_features.lua
@@ -784,7 +784,7 @@ function ZVM:Interrupt(interruptNo,interruptParameter,isExternal,cascadeInterrup
       if FLAGS[7] == 1 then
         self.PTBL = NewPTB
       elseif FLAGS[8] == 1 then
-        self.PTBE = 1
+        self.PTBE = NewPTB
       end
 
     elseif self.PF == 1 then -- Compatibility extended mode


### PR DESCRIPTION
In the code for the interrupt handler, there is a small table of what the interrupt flags should do
```
      --Flags:
      --3  [8 ] = CMPR shows if interrupt occured
      --4  [16] = Interrupt does not set CS
      --5  [32] = Interrupt enabled
      --6  [64] = NMI interrupt
      --7  [128] = Replace PTBL with NewPTE (overrides #8)
      --8  [256] = Replace PTBE with NewPTE
      --9  [512] = Push extended registers (R0-R31)
```

This brings interrupt flag 8, (Replace page table entries with page table byte from interrupt descriptor) closer to what the comment implies it should do, due to a possible mistake in the original implementation in [this commit](https://github.com/wiremod/wire/commit/151f9526835ba1ac0b6869998f5d5acc4ad015b6) and [this second commit claiming to fix it](https://github.com/wiremod/wire/commit/f0aa0cdb7003f0606fd0199a1c1c0aa7c8b7ef29), both from 11 years ago.

Since setting the page table and page table entries are intended to not be possible at the same time, setting page table entries to 1 seems to be a mistake even if it was claimed to be fixed, unless the intended usecase was for the programmer to then go and find the interrupt descriptor and set the number of page table entries themselves now that they're not being remapped?

The original author appears to have no github, somehow, so I can't contact them to ask if this was intended.