### PR TITLE
ZCPU examples for interrupts, segments, and stack

### DIFF
--- a/data/cpuchip/examples/interrupts.txt
+++ b/data/cpuchip/examples/interrupts.txt
@@ -1,0 +1,109 @@
+/*
+This example assumes you are already familiar with ZASM
+as this will be going over advanced features.
+
+For setup of this example:
+
+1. Wire a button outputting value 32 to the Interrupt input on the CPU
+2. Connect CPU membus input to a console screen
+*/
+
+DATA
+
+/*
+Each external interrupt is 4 bytes
+formatted like so:
+Instruction Pointer, Code Segment, PTB, Flags
+Available flags are
+Bit 3(8)  : Interrupt will set CMPR to 1, unavailable for external interrupts(they restore CMPR on EXTRET)
+Bit 4(16) : Interrupt will not set CS
+Bit 5(32) : Interrupt is enabled
+Bit 6(64) : Interrupt is external
+Bit 7(128): Interrupt will replace page table with PTB, which isn't restored on IRET/EXTRET
+Bit 8(256): Interrupt will replace number of page table entries with PTB, which isn't restored on IRET/EXTRET
+Bit 9(512): Interrupt will also push R0-R31 to stack, use EXTRETA instead of EXTRET to pop them
+
+Flags can be combined, do this by adding the numbers together
+For example:
+8+32 = Interrupt is active, and on interrupt it will set CMPR to 1
+*/
+my_interrupt_table:
+ALLOC 32*4 // The interrupt table is 0 indexed
+DB my_external_interrupt,0,0,96 // so this is index 32
+DB my_internal_interrupt,0,0,32 // and this is index 33
+DB my_timer_interrupt,0,0,96 // Timer interrupts need to be external
+ALLOC 24*4 // Fill rest of space to 58 usable interrupts
+
+external_int_str:
+DB "Hello from External Interrupt!",0
+
+internal_int_str:
+DB "Hello from Internal Interrupt!",0
+
+timer_int_str:
+DB "Hello from the Timer Interrupt",0
+
+my_external_interrupt:
+    CLI // Turn off the ability for another interrupt to happen
+    CPUGET EDI,43 // get external memory and put it in EDI
+    ADD EDI,60    // shift mem offset to start on line 2 of console screen
+    MOV ESI,external_int_str
+    external_int_strcpy: // Copy null terminated string
+        MOV [EDI],[ESI]
+        MCOPY 1
+        MOV [EDI],999 // See helloworld.txt for more information about console colors
+        INC EDI
+        CMP [ESI],0
+    JNE external_int_strcpy
+    CLERR // Clear error code on CPU
+    STI // Re-enable interrupts before returning from interrupt
+EXTRET // You need to use the EXTRET instruction for external interrupts, since IRET only pops IP and CS
+// EXTRET pops all 20 bytes from stack that are generated upon an external interrupt
+
+my_internal_interrupt:
+    // If CLI at start is not present, this interrupt can be interrupted
+    // by another interrupt happening during execution.
+    CPUGET EDI,43 // get external memory and put it in EDI
+    MOV ESI,internal_int_str
+    internal_int_strcpy: // Copy null terminated string
+        MOV [EDI],[ESI]
+        MCOPY 1
+        MOV [EDI],999 // See helloworld.txt for more information about console colors
+        INC EDI
+        CMP [ESI],0
+    JNE internal_int_strcpy
+    CLERR // Clear error code on CPU
+IRET // Registers are not preserved in an internal interrupt, IRET only pops CS and IP to return to
+
+my_timer_interrupt:
+    CLI
+    CPUGET EDI,43 // get external memory and put it in EDI
+    ADD EDI,120   // shift mem offset to start on line 3 of console screen
+    MOV ESI,timer_int_str
+    timer_int_strcpy: // Copy null terminated string
+        MOV [EDI],[ESI]
+        MCOPY 1
+        MOV [EDI],999 // See helloworld.txt for more information about console colors
+        INC EDI
+        CMP [ESI],0
+    JNE timer_int_strcpy
+    CLERR // Clear error code on CPU
+    STI // re-enable interrupts
+EXTRET // Registers are not preserved in an internal interrupt, IRET only pops CS and IP to return to
+
+
+CODE
+STEF // Set the EXTENDED FLAG on, this allows you to call interrupts without halting CPU
+LIDTR my_interrupt_table // Load the interrupt table we have in memory
+CPUSET 52,59 // Set number of interrupts in table (defaults to 256)
+INT 33 // Call interrupt 33 to print to console screen.
+// Note that you can also call external interrupts internally using EXTINT (number)
+CPUSET 67,34 // Set timer interrupt(external interrupt #) to our timer interrupt
+CPUSET 65,4  // Set delay on timer to 4 seconds.
+CPUSET 64,1  // Set timer mode to seconds (it will read the 4 as 4 seconds, set to 2 to read as every 4 instructions)
+// Timer will now be running from here on.
+
+wait_forever:
+INC R0
+JMP wait_forever
+// Use CLEF to disable the extended flag if you want to halt on error instead of handle

--- a/data/cpuchip/examples/segments.txt
+++ b/data/cpuchip/examples/segments.txt
@@ -50,9 +50,9 @@ MOV R4,[EAX:0] // and any register can be used as a segment
 MOV R5,R0:0    // This does nothing
 
 /*
-LEA is currently the only instruction that uses a user defined segment
-outside of memory access, and it writes the value of segment+value
-to the left hand side, it is effectively the same as
+LEA is one of the few instructions that use a user defined segment
+outside of memory access, and it writes the value of the address used
+by a memory access to the left hand side, it is effectively the same as
 
 MOV EAX,R0 //(EAX is just a standin for an unused register)
 ADD EAX,DS //(or the segment explicitly defined instead of DS)
@@ -65,8 +65,8 @@ this code uses 6 bytes, where LEA uses:
 
 */ 
 
-LEA R6,R0    // This will put DS+R0 into R6 (data_pos+3)
-LEA R7,SS:R0 // This will put SS+R0 into R7(SS+3)
+LEA R6,[R0]    // This will put DS+R0 into R6 (data_pos+3)
+LEA R7,[SS:R0] // This will put SS+R0 into R7(SS+3)
 
 /*
 Wire your CPU to a memory device

--- a/data/cpuchip/examples/segments.txt
+++ b/data/cpuchip/examples/segments.txt
@@ -1,0 +1,91 @@
+/*
+This example assumes you are already familiar with ZASM
+as this will be going over semi-advanced features.
+
+Segment registers allow you to add an offset to memory access
+By default, they are all set to 0 on first startup of CPU
+and reset to 0 when the CPU is reset.
+
+The available segment registers are
+CS - Code Segment, used to read instructions from RAM.
+     It can only be changed with far jump instructions, trying to
+     set it using other instructions results in an error of #13[1]
+
+     Setting this allows compiled programs using branches to run
+     without having to be compiled knowing where they will sit in
+     memory
+
+SS - Stack Segment, this is where the stack starts from, stack access
+     via PUSH, POP, RSTACK, SSTACK is relative to this segment
+
+DS - Data Segment, default for all memory access instructions
+     unless another segment is specified.
+
+User Segments, none of these are used internally, so they can be used
+without fear of altering behavior outside of user programs which use
+these segments
+ES - Extra Segment
+GS - "G Segment"
+FS - "F Segment"
+KS - Key Segment
+LS - Library Segment
+*/
+
+// Segment registers can be read and written to like any other register
+start:
+MOV DS,data_pos
+MOV R0,3
+MOV R1,[R0] // 3+data_pos, aka the fourth value, 720. Doesn't change R0
+            // or DS in order to access and store the value in R1
+MOV R2,[0]  // 0+data_pos, aka the first value, 640.
+JMP end_data_pos
+data_pos:
+DB 640,480
+DB 1280,720
+DB 0
+end_data_pos:
+
+MOV R3,[CS:0]  // Segment for access can be specified with SEG:Value
+MOV R4,[EAX:0] // and any register can be used as a segment
+MOV R5,R0:0    // This does nothing
+
+/*
+LEA is currently the only instruction that uses a user defined segment
+outside of memory access, and it writes the value of segment+value
+to the left hand side, it is effectively the same as
+
+MOV EAX,R0 //(EAX is just a standin for an unused register)
+ADD EAX,DS //(or the segment explicitly defined instead of DS)
+MOV R7,EAX
+
+^
+this code uses 6 bytes, where LEA uses:
+2 bytes(no segment supplied, register to register transfer I.E LEA R7,R0)
+3 bytes(segment supplied by user, register to register transfer I.E LEA R7,SS:R0)
+
+*/ 
+
+LEA R6,R0    // This will put DS+R0 into R6 (data_pos+3)
+LEA R7,SS:R0 // This will put SS+R0 into R7(SS+3)
+
+/*
+Wire your CPU to a memory device
+and upload your own program to the device
+by clicking on it as if it were a CPU
+ 
+If this example is uploaded to your CPU
+it will begin running the code on the
+memory device as if it were running on
+the original CPU, to debug the program
+press compile with your code open in the
+editor, afterward "Step Forward" will begin
+showing the proper lines.
+*/
+
+CPUGET DS,43 // Get RAM size of CPU, aka the first byte of external memory.
+JMPF 0,DS   // JMP to 0 + DS, setting CS to DS
+
+/*
+Your program will now run from here until
+it errors or you reset it.
+*/

--- a/data/cpuchip/examples/stack_setup.txt
+++ b/data/cpuchip/examples/stack_setup.txt
@@ -1,0 +1,37 @@
+/*
+This example assumes you are already familiar with ZASM
+as this will be going over semi-advanced features.
+
+Contains example code for how to change your CPU's stack
+segment and size, and print a string to a console screen
+using only stack instructions
+
+By default, on a CPU the stack segment starts at 0, and
+the stack size is set to the RAM size, so if you push to
+it too many times, you might start overwriting your own
+code on the CPU, setting up a dedicated stack segment and
+stack area is a good idea if you don't know how much stack
+your program could possibly consume.
+*/
+
+CPUGET SS,43 // Set stack segment register to the CPU's internal ram size
+             // This will make stack operations access external memory
+SUB SS,4     // Move SS back by 2 console screen characters(2 bytes each)
+CPUSET 9,32  // Set internal register 9(ESZ, aka stack size) + 2 console chars
+MOV ESP,32   // Set stack pointer to stack size
+             // You can also use CPUGET ESP,9 to set ESP to current stack size
+
+MOV ESI,str-1 // Loops end at 0, so we need to start at -1 if we want
+              // to read from something with 0 indexing
+
+MOV ECX,15 // String length + 1
+// Remember that stack access is done top(SS+ESP) to bottom
+// This reads the string in reverse to push it to stack
+print_loop:
+PUSH [ESI:ECX] // Using ESI(containing ptr to str) as a segment to access ECX
+PUSH 999       // See helloworld.txt for more information about console colors
+LOOP print_loop
+
+str:
+DB "Hi from Stack!" // 14 characters
+


### PR DESCRIPTION
Includes three new CPU examples, which show working code, detailing the following;

interrupts.txt: Loading an Interrupt table with an external, internal, and a timer called interrupt, to print three separate strings to a console screen
segments.txt: Segment theory & use, as well as an example of running user code from the membus as if it were on the CPU itself
stack_setup.txt: Setting up a stack by setting the stack registers(segment,size,pointer), and using it in a practical example to push a hello world to a console screen

If I made any mistakes, or if there's a clearer way to word these concepts, let me know and I can correct the files.