### PR TITLE
Fix emits killing lua on emitted interrupt

### DIFF
--- a/lua/wire/zvm/zvm_core.lua
+++ b/lua/wire/zvm/zvm_core.lua
@@ -269,7 +269,7 @@ function ZVM:Dyn_EmitInterrupt(intNo,intParam)
   self:Dyn_EmitState()
   self:Emit("VM.IP = %d",(self.PrecompileIP or 0))
   self:Emit("VM.XEIP = %d",(self.PrecompileTrueXEIP or 0))
-  self:Dyn_Emit("VM:Interrupt(%d,%d)",intNo,intParam)
+  self:Dyn_Emit("VM:Interrupt(%s,%s)",intNo,intParam)
   self:Dyn_EmitBreak()
 end
 

--- a/lua/wire/zvm/zvm_core.lua
+++ b/lua/wire/zvm/zvm_core.lua
@@ -265,6 +265,8 @@ end
 
 --------------------------------------------------------------------------------
 -- Emit interrupt call
+-- intNo can only be numeric or "$1"
+-- intParam can only be numeric or "IDX"
 function ZVM:Dyn_EmitInterrupt(intNo,intParam)
   self:Dyn_EmitState()
   self:Emit("VM.IP = %d",(self.PrecompileIP or 0))

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -238,7 +238,7 @@ ZVM.OpcodeTable[29] = function(self)  --CPG
   self:Dyn_Emit("$L PAGE = VM:GetPageByIndex(IDX)")
   self:Dyn_EmitInterruptCheck()
 
-  self:Dyn_Emit("if VM.CurrentPage.RunLevel <= VM.Page[IDX].RunLevel then")
+  self:Dyn_Emit("if VM.CurrentPage.RunLevel <= PAGE.RunLevel then")
     self:Dyn_Emit("PAGE.Read = 1")
     self:Dyn_Emit("PAGE.Write = 1")
     self:Dyn_Emit("VM:SetPageByIndex(IDX)")

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -234,11 +234,11 @@ ZVM.OpcodeTable[28] = function(self)  --SPG
   self:Dyn_Emit("end")
 end
 ZVM.OpcodeTable[29] = function(self)  --CPG
-  self:Dyn_Emit("$L idx = math.floor($1 / 128)")
+  self:Dyn_Emit("$L IDX = math.floor($1 / 128)")
   self:Dyn_Emit("$L PAGE = VM:GetPageByIndex(IDX)")
   self:Dyn_EmitInterruptCheck()
 
-  self:Dyn_Emit("if VM.CurrentPage.RunLevel <= VM.Page[idx].RunLevel then")
+  self:Dyn_Emit("if VM.CurrentPage.RunLevel <= VM.Page[IDX].RunLevel then")
     self:Dyn_Emit("PAGE.Read = 1")
     self:Dyn_Emit("PAGE.Write = 1")
     self:Dyn_Emit("VM:SetPageByIndex(IDX)")


### PR DESCRIPTION
Currently from the main branch after #27, attempting to use the INT, SPG, CPG, SPP, CPP, SRL, and SMAP instructions may cause a lua error, relating to string.format of Dyn_EmitInterrupt expecting both arguments to be numbers(how naive of me)

In the case of INT, because it passes the string $1(macro for first operand of the instruction, which hasn't been replaced with the final name yet) to Dyn_EmitInterrupt()

In the case of the paging instructions listed, because they pass the string IDX as second argument to Dyn_EmitInterrupt().