### PR TITLE
Correct the mario_theme example for SPU

### DIFF
--- a/data/spuchip/examples/mario_theme.txt
+++ b/data/spuchip/examples/mario_theme.txt
@@ -25,10 +25,12 @@ tracklen = strlen(trackA);
 void main()
 {
     // Tempo
-    if ((i > 120) && (i <= 230))
+    if ((i > 120) && (i <= 230)) {
         tempo( 1000 );
-    else
+    }
+    else {
         tempo( 864 );
+    }
 
     // Track A
     note = 2;


### PR DESCRIPTION
Turns out the code for the tempo control only ran between notes 120 and 230, the tempo(864) was ignored because there were no curly braces, which explains the garbled mess of notes at the beginning and end.

Comparison video
https://github.com/wiremod/wire-cpu/assets/57756830/b3875325-a76a-4fc6-93c9-a817623f267b

If #33 passes before this I'll change the folder to data_static, else I'll update #33 to have this change in the proper folder