### PR TITLE
Else in nested ifdefs fixed for new ifdef handling

### DIFF
--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -38,12 +38,18 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
 
   -- Stop parsing macros inside of a failed ifdef/ifndef
   if self.SkipToEndIf then
-    if macroName == "endif" or macroName == "else" then
+    if macroName == "else" then
+      if self.EndIfsToSkip == 0 then
+        self.SkipToEndIf = false
+        return self:ParsePreprocessMacro(lineText,macroPosition) -- Rerun function to parse else correctly
+      end
+    end
+    if macroName == "endif" then
       if self.EndIfsToSkip > 0 then 
         self.EndIfsToSkip = self.EndIfsToSkip - 1
       else
         self.SkipToEndIf = false
-        return self:ParsePreprocessMacro(lineText,macroPosition) -- Rerun function to parse endif/else correctly
+        return self:ParsePreprocessMacro(lineText,macroPosition) -- Rerun function to parse endif correctly
       end
     end
     if macroName == "ifdef" or macroName == "ifndef" then


### PR DESCRIPTION
#else decrementing the number of ifdefs to skip can cause it to break out early and parse one too many endifs, breaking the compiler.

Consider the following:
```
// x is undefined
// y can be defined or undefined while still causing the error
#ifdef x

#ifdef y // skip = 1

#else    // skip = 0

#endif   // break out of skipping and parse as endif for #ifdef x

#endif // error: ENDIF without matching IFDEF/IFNDEF
```

This will make an #else only stop skipping when it would have stopped skipping on the next #endif anyway

Demonstration of the fixed behavior
```
// x is undefined
// y can be defined or undefined with neither case causing an error
#ifdef x

#ifdef y // skip = 1

#else    // skip is still 1

#endif   // skip = 0

#endif // break out of skipping and parse as endif for #ifdef x
```