### PR TITLE
Bit operations below 33 bits now use the inbuilt bitwise library

### DIFF
--- a/lua/wire/zvm/zvm_data.lua
+++ b/lua/wire/zvm/zvm_data.lua
@@ -12,6 +12,7 @@
 ZVM.InternalRegister = {}
 ZVM.InternalLimits = {IPREC = {1, 128}}
 ZVM.ReadOnlyRegister = {}
+ZVM.IntegerOnlyRegister = {}
 
 ZVM.InternalRegister[00] = "IP"
 ZVM.InternalRegister[01] = "EAX"
@@ -63,7 +64,7 @@ ZVM.InternalRegister[47] = "INTR"
 ZVM.InternalRegister[48] = "SerialNo"            ZVM.ReadOnlyRegister[48] = true
 ZVM.InternalRegister[49] = "CODEBYTES"           ZVM.ReadOnlyRegister[49] = true
 ZVM.InternalRegister[50] = "BPREC"
-ZVM.InternalRegister[51] = "IPREC"
+ZVM.InternalRegister[51] = "IPREC"               ZVM.IntegerOnlyRegister[51] = true
 ZVM.InternalRegister[52] = "NIDT"
 ZVM.InternalRegister[53] = "BlockStart"
 ZVM.InternalRegister[54] = "BlockSize"

--- a/lua/wire/zvm/zvm_features.lua
+++ b/lua/wire/zvm/zvm_features.lua
@@ -1115,7 +1115,13 @@ function ZVM:BinarySHL(n,cnt)
   return self:BinaryToInteger(bits)
 end
 
-
+--------------------------------------------------------------------------------
+-- Clamps numbers to within a certain binary range using BAND
+-- if IPREC were 4 then 2^4 = 16, or 0b10000
+-- subtracting 1 from 16 would make it 0b01111, which is a mask for the first 4 bits
+function ZVM:ClampBinaryToIPREC(num)
+  return bit.band(num,math.pow(2,self.IPREC)-1)
+end
 
 
 --------------------------------------------------------------------------------

--- a/lua/wire/zvm/zvm_features.lua
+++ b/lua/wire/zvm/zvm_features.lua
@@ -1120,7 +1120,14 @@ end
 -- if IPREC were 4 then 2^4 = 16, or 0b10000
 -- subtracting 1 from 16 would make it 0b01111, which is a mask for the first 4 bits
 function ZVM:ClampBinaryToIPREC(num)
-  return bit.band(num,math.pow(2,self.IPREC)-1)
+  local finalvalue = bit.band(num,math.pow(2,self.IPREC)-1)
+  if self.IPREC < 32 then
+    local msb = math.pow(2,self.IPREC-1)
+    if bit.band(msb,finalvalue) ~= 0 then 
+      return finalvalue - msb*2
+    end
+  end
+  return finalvalue
 end
 
 

--- a/lua/wire/zvm/zvm_features.lua
+++ b/lua/wire/zvm/zvm_features.lua
@@ -1120,9 +1120,9 @@ end
 -- if IPREC were 4 then 2^4 = 16, or 0b10000
 -- subtracting 1 from 16 would make it 0b01111, which is a mask for the first 4 bits
 function ZVM:ClampBinaryToIPREC(num)
-  local finalvalue = bit.band(num,math.pow(2,self.IPREC)-1)
+  local finalvalue = bit.band(num,math.ldexp(1,self.IPREC)-1)
   if self.IPREC < 32 then
-    local msb = math.pow(2,self.IPREC-1)
+    local msb = math.ldexp(1,self.IPREC-1)
     if bit.band(msb,finalvalue) ~= 0 then 
       return finalvalue - msb*2
     end
@@ -1130,6 +1130,13 @@ function ZVM:ClampBinaryToIPREC(num)
   return finalvalue
 end
 
+--------------------------------------------------------------------------------
+-- Performs ldexp with constant 1 significand and exp floored automatically.
+-- to get a value with only bit [num] enabled
+-- required because ldexp normally errors when a non-integer is passed as exp
+function ZVM:GetBit(num)
+  return math.ldexp(1,math.floor(num))
+end
 
 --------------------------------------------------------------------------------
 -- Reset to initial state

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -268,7 +268,7 @@ ZVM.OpcodeTable[32] = function(self)  --BNOT
   self:Dyn_Emit("if VM.IPREC > 32 then")
     self:Dyn_EmitOperand("VM:BinaryNot($1)")
   self:Dyn_Emit("else")
-    self:Dyn_EmitOperand("VM:ClampBinaryToIPREC(bit.bnot($1,$2))")
+    self:Dyn_EmitOperand("VM:ClampBinaryToIPREC(bit.bnot($1))")
   self:Dyn_Emit("end")
 end
 ZVM.OpcodeTable[33] = function(self)  --FINT
@@ -416,7 +416,7 @@ ZVM.OpcodeTable[60] = function(self)  --BIT
     self:Dyn_Emit("VM.CMPR = BITS[math.floor($2)] or 0")
     self:Dyn_Emit("VM.TMR = VM.TMR + 30")
   self:Dyn_Emit("else")
-    self:Dyn_Emit("if bit.band($1,math.pow(2,$2)) ~= 0 then")
+    self:Dyn_Emit("if bit.band($1,VM:GetBit($2)) ~= 0 then")
       self:Dyn_Emit("VM.CMPR = 1")
     self:Dyn_Emit("else")
       self:Dyn_Emit("VM.CMPR = 0")
@@ -430,7 +430,7 @@ ZVM.OpcodeTable[61] = function(self)  --SBIT
     self:Dyn_EmitOperand("VM:BinaryToInteger(BITS)")
     self:Dyn_Emit("VM.TMR = VM.TMR + 20")
   self:Dyn_Emit("else")
-    self:Dyn_EmitOperand("VM:ClampBinaryToIPREC(bit.bor($1,math.pow(2,$2)))")
+    self:Dyn_EmitOperand("VM:ClampBinaryToIPREC(bit.bor($1,VM:GetBit($2)))")
   self:Dyn_Emit("end")
 end
 ZVM.OpcodeTable[62] = function(self)  --CBIT
@@ -440,7 +440,7 @@ ZVM.OpcodeTable[62] = function(self)  --CBIT
     self:Dyn_EmitOperand("VM:BinaryToInteger(BITS)")
     self:Dyn_Emit("VM.TMR = VM.TMR + 20")
   self:Dyn_Emit("else")
-    self:Dyn_EmitOperand("VM:ClampBinaryToIPREC(bit.band($1,math.pow(2,$2)))")
+    self:Dyn_EmitOperand("VM:ClampBinaryToIPREC(bit.band($1,VM:GetBit($2)))")
   self:Dyn_Emit("end")
 end
 ZVM.OpcodeTable[63] = function(self)  --TBIT
@@ -450,7 +450,7 @@ ZVM.OpcodeTable[63] = function(self)  --TBIT
     self:Dyn_EmitOperand("VM:BinaryToInteger(BITS)")
     self:Dyn_Emit("VM.TMR = VM.TMR + 30")
   self:Dyn_Emit("else")
-    self:Dyn_EmitOperand("VM:ClampBinaryToIPREC(bit.bxor($1,math.pow(2,$2)))")
+    self:Dyn_EmitOperand("VM:ClampBinaryToIPREC(bit.bxor($1,VM:GetBit($2)))")
   self:Dyn_Emit("end")
 end
 ZVM.OpcodeTable[64] = function(self)   --BAND
@@ -970,7 +970,11 @@ ZVM.OpcodeTable[121] = function(self)  --CPUSET
   self:Dyn_Emit("if VM.InternalRegister[REG] and (not VM.ReadOnlyRegister[REG]) then")
     self:Dyn_Emit("$L OP = $2")
     self:Dyn_Emit("$L limit = VM.InternalLimits[REG]")
-    self:Dyn_Emit("VM[VM.InternalRegister[REG]] = limit and math.Clamp(OP, limit[1], limit[2]) or OP")
+    self:Dyn_Emit("if VM.IntegerOnlyRegister[REG] then")
+      self:Dyn_Emit("VM[VM.InternalRegister[REG]] = math.floor(limit and math.Clamp(OP, limit[1], limit[2]) or OP)")
+    self:Dyn_Emit("else")
+      self:Dyn_Emit("VM[VM.InternalRegister[REG]] = limit and math.Clamp(OP, limit[1], limit[2]) or OP")
+    self:Dyn_Emit("end")
     self:Dyn_Emit("if (REG == 0) or (REG == 16) then")
       self:Dyn_Emit("VM:Jump(%d,VM.CS)",self.PrecompileIP)
       self:Dyn_EmitState()

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -416,7 +416,11 @@ ZVM.OpcodeTable[60] = function(self)  --BIT
     self:Dyn_Emit("VM.CMPR = BITS[math.floor($2)] or 0")
     self:Dyn_Emit("VM.TMR = VM.TMR + 30")
   self:Dyn_Emit("else")
-    self:Dyn_Emit("VM.CMPR = bit.band($1,math.pow(2,$2))")
+    self:Dyn_Emit("if bit.band($1,math.pow(2,$2)) ~= 0 then")
+      self:Dyn_Emit("VM.CMPR = 1")
+    self:Dyn_Emit("else")
+      self:Dyn_Emit("VM.CMPR = 0")
+    self:Dyn_Emit("end")
   self:Dyn_Emit("end")
 end
 ZVM.OpcodeTable[61] = function(self)  --SBIT


### PR DESCRIPTION
When the IPREC register is at 32 or below, it will now use the bit library and then clamp it to the desired integer precision using a BAND

For demonstrative purposes, the left CPU is using a modified version of the old BSHL with the 30 cycle penalty removed, and the right CPU is using the new BSHR which will have no cycle penalty at 32 bit and below IPREC, both CPUs are set to 32 bit precision.

Both CPUs are at 14MHz, which is 10x the default limit of 1.4MHz

https://github.com/wiremod/wire-cpu/assets/57756830/71824bcb-56a8-4fa4-a545-4473aa6c7c00