### PR TITLE
CPULib Extension framework

### DIFF
--- a/lua/autorun/cpu_load.lua
+++ b/lua/autorun/cpu_load.lua
@@ -20,6 +20,7 @@ AddCSLuaFile("wire/zvm/zvm_data.lua")
 AddCSLuaFile("wire/cpulib.lua")
 include("wire/cpulib.lua")
 
+AddCSLuaFile("wire/cpulib_example_extension.lua")
 include("wire/cpulib_example_extension.lua")
 
 AddCSLuaFile("wire/gpulib.lua")

--- a/lua/autorun/cpu_load.lua
+++ b/lua/autorun/cpu_load.lua
@@ -20,8 +20,8 @@ AddCSLuaFile("wire/zvm/zvm_data.lua")
 AddCSLuaFile("wire/cpulib.lua")
 include("wire/cpulib.lua")
 
-AddCSLuaFile("wire/cpulib_example_extension.lua")
-include("wire/cpulib_example_extension.lua")
+-- AddCSLuaFile("wire/cpulib_example_extension.lua")
+-- include("wire/cpulib_example_extension.lua")
 
 AddCSLuaFile("wire/gpulib.lua")
 include("wire/gpulib.lua")

--- a/lua/autorun/cpu_load.lua
+++ b/lua/autorun/cpu_load.lua
@@ -20,6 +20,8 @@ AddCSLuaFile("wire/zvm/zvm_data.lua")
 AddCSLuaFile("wire/cpulib.lua")
 include("wire/cpulib.lua")
 
+include("wire/cpulib_example_extension.lua")
+
 AddCSLuaFile("wire/gpulib.lua")
 include("wire/gpulib.lua")
 

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -34,6 +34,10 @@ function ENT:Initialize()
 	self.VM.MemoryWriteCycles = 2
 	self.VM.ExternalReadCycles = 8
 	self.VM.ExternalWriteCycles = 8
+	if self.ZVMExtensions then
+		self.VM.Extensions = CPULib:FromExtensionString(self.ZVMExtensions,"CPU")
+		CPULib:LoadExtensions(self.VM,"CPU")
+	end
 	self.VM:Reset()
 
 	self:SetCPUName()
@@ -138,6 +142,14 @@ local memoryModels = {
 function ENT:SetMemoryModel(model)
 	self.VM.RAMSize = memoryModels[model][1] or 65536
 	self.VM.ROMSize = memoryModels[model][2] or 65536
+end
+
+function ENT:SetExtensionLoadOrder(extstr)
+	self.ZVMExtensions = extstr
+	if self.VM then
+		self.VM.Extensions = CPULib:FromExtensionString(self.ZVMExtensions,"CPU")
+		CPULib:LoadExtensions(self.VM,"CPU")
+	end
 end
 
 -- Execute ZCPU virtual machine
@@ -248,6 +260,7 @@ function ENT:BuildDupeInfo()
 	info.InternalRAMSize = self.VM.RAMSize
 	info.InternalROMSize = self.VM.ROMSize
 	info.CPUName         = self.CPUName
+	info.ZVMExtensions   = self.ZVMExtensions
 
 	if self.VM.ROMSize > 0 then
 		info.Memory = {}
@@ -264,6 +277,8 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	self.VM.RAMSize  = info.InternalRAMSize or 65536
 	self.VM.ROMSize  = info.InternalROMSize or 65536
 	self:SetCPUName(info.CPUName)
+
+	self.ZVMExtensions = info.ZVMExtensions
 
 	if info.Memory then--and
 		 --(((info.UseROM) and (info.UseROM == true)) or

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -277,8 +277,8 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	self.VM.RAMSize  = info.InternalRAMSize or 65536
 	self.VM.ROMSize  = info.InternalROMSize or 65536
 	self:SetCPUName(info.CPUName)
+	self:SetExtensionLoadOrder(info.ZVMExtensions)
 
-	self.ZVMExtensions = info.ZVMExtensions
 
 	if info.Memory then--and
 		 --(((info.UseROM) and (info.UseROM == true)) or

--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -185,7 +185,10 @@ function ENT:OverrideVM()
   self.VM.OperandCount[131] = nil --SMAP
   self.VM.OperandCount[132] = nil --GMAP
 
-  CPULib:LoadExtensions(self.VM,"GPU")
+  if self.ZVMExtensions then
+    self.VM.Extensions = CPULib:FromExtensionString(self.ZVMExtensions,"GPU")
+    CPULib:LoadExtensions(self.VM,"GPU")
+  end
 
   -- Add some extra lookups
   self.VM.FontName = {}

--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -185,6 +185,8 @@ function ENT:OverrideVM()
   self.VM.OperandCount[131] = nil --SMAP
   self.VM.OperandCount[132] = nil --GMAP
 
+  CPULib:LoadExtensions(self.VM,"GPU")
+
   -- Add some extra lookups
   self.VM.FontName = {}
   self.VM.FontName[0] = "Lucida Console"

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -46,7 +46,6 @@ usermessage.Hook("wire_gpu_monitorstate", GPU_MonitorState)
 -- Update GPU features/memory model
 --------------------------------------------------------------------------------
 local function GPU_MemoryModel(um)
-  print("setmemory")
   local GPU = ents.GetByIndex(um:ReadLong())
   if not GPU then return end
   if not GPU:IsValid() then return end
@@ -64,13 +63,11 @@ end
 usermessage.Hook("wire_gpu_memorymodel", GPU_MemoryModel)
 
 local function GPU_SetExtensions(um)
-  print("setextensions")
   local GPU = ents.GetByIndex(um:ReadLong())
   if not GPU then return end
   if not GPU:IsValid() then return end
   local extstr = um:ReadString()
   local extensions = CPULib:FromExtensionString(extstr,"GPU")
-  print("umsg "..extstr)
   if GPU.VM then
     GPU.VM.Extensions = extensions
     CPULib:LoadExtensions(GPU.VM,"GPU")
@@ -93,8 +90,6 @@ function ENT:Initialize()
   self.VM.CPUTYPE = 1 -- ZGPU
   self.ChipType   = 0
   self.VM.Extensions = CPULib:FromExtensionString(self.ZVMExtensions,"GPU")
-  --print(self.ZVMExtensions)
-  --PrintTable(self.VM.Extensions)
 
   -- Hard-reset VM and override it
   self:OverrideVM()
@@ -207,7 +202,6 @@ function ENT:Run(isAsync)
   else
     self.VM.SyncQuotaOverrun = self.VM.QuotaOverrunFunc
     if self.VM.SyncQuotaOverrun then
-      print(self.VM.LateFrames)
       self.VM.SyncQuotaIP = self.VM.IP
       self.VM.LateFrames = self.VM.LateFrames + 1
     else

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -46,6 +46,7 @@ usermessage.Hook("wire_gpu_monitorstate", GPU_MonitorState)
 -- Update GPU features/memory model
 --------------------------------------------------------------------------------
 local function GPU_MemoryModel(um)
+  print("setmemory")
   local GPU = ents.GetByIndex(um:ReadLong())
   if not GPU then return end
   if not GPU:IsValid() then return end
@@ -62,6 +63,22 @@ local function GPU_MemoryModel(um)
 end
 usermessage.Hook("wire_gpu_memorymodel", GPU_MemoryModel)
 
+local function GPU_SetExtensions(um)
+  print("setextensions")
+  local GPU = ents.GetByIndex(um:ReadLong())
+  if not GPU then return end
+  if not GPU:IsValid() then return end
+  local extstr = um:ReadString()
+  local extensions = CPULib:FromExtensionString(extstr,"GPU")
+  print("umsg "..extstr)
+  if GPU.VM then
+    GPU.VM.Extensions = extensions
+    CPULib:LoadExtensions(GPU.VM,"GPU")
+  end
+  GPU.ZVMExtensions = extstr
+end
+usermessage.Hook("wire_gpu_extensions", GPU_SetExtensions)
+
 local wire_gpu_frameratio = CreateClientConVar("wire_gpu_frameratio",4)
 
 function ENT:Initialize()
@@ -75,6 +92,9 @@ function ENT:Initialize()
   self.VM.CPUVER  = 1.0 -- Beta GPU by default
   self.VM.CPUTYPE = 1 -- ZGPU
   self.ChipType   = 0
+  self.VM.Extensions = CPULib:FromExtensionString(self.ZVMExtensions,"GPU")
+  --print(self.ZVMExtensions)
+  --PrintTable(self.VM.Extensions)
 
   -- Hard-reset VM and override it
   self:OverrideVM()

--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -75,6 +75,18 @@ function ENT:SetMemoryModel(model,initial)
   end
 end
 
+function ENT:SetExtensionLoadOrder(extstr)
+  self.ZVMExtensions = extstr
+  timer.Simple(0.1+math.random()*0.3,
+  function()
+    if not self:IsValid() then return end
+
+    umsg.Start("wire_gpu_extensions")
+      umsg.Long(self:EntIndex())
+      umsg.String(self.ZVMExtensions)
+    umsg.End()
+  end)
+end
 
 --------------------------------------------------------------------------------
 -- Resend all GPU cache to newly spawned player
@@ -180,6 +192,7 @@ function ENT:BuildDupeInfo()
   info.RAMSize = self.RAMSize
   info.ChipType = self.ChipType
   info.Memory = {}
+  info.ZVMExtensions = self.ZVMExtensions
 
   for address = 0,self.RAMSize-1 do
     if self.Memory[address] and (self.Memory[address] ~= 0) then info.Memory[address] = self.Memory[address] end
@@ -199,6 +212,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
   self.RAMSize  = math.Clamp(info.RAMSize or 65536, 0, 2097152)
   self.ChipType = info.ChipType or 0
   self.Memory = {}
+  self.ZVMExtensions = info.ZVMExtensions
 
   for address = 0,self.RAMSize-1 do
     if info.Memory[address] then self.Memory[address] = tonumber(info.Memory[address]) or 0 end

--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -212,7 +212,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
   self.RAMSize  = math.Clamp(info.RAMSize or 65536, 0, 2097152)
   self.ChipType = info.ChipType or 0
   self.Memory = {}
-  self.ZVMExtensions = info.ZVMExtensions
+  self:SetExtensionLoadOrder(info.ZVMExtensions)
 
   for address = 0,self.RAMSize-1 do
     if info.Memory[address] then self.Memory[address] = tonumber(info.Memory[address]) or 0 end

--- a/lua/entities/gmod_wire_spu/cl_init.lua
+++ b/lua/entities/gmod_wire_spu/cl_init.lua
@@ -90,6 +90,19 @@ local function SPU_MemoryModel(um)
 end
 usermessage.Hook("wire_spu_memorymodel", SPU_MemoryModel)
 
+local function SPU_SetExtensions(um)
+  local SPU = ents.GetByIndex(um:ReadLong())
+  if not SPU then return end
+  if not SPU:IsValid() then return end
+  local extstr = um:ReadString()
+  local extensions = CPULib:FromExtensionString(extstr,"SPU")
+  if SPU.VM then
+    SPU.VM.Extensions = extensions
+    CPULib:LoadExtensions(SPU.VM,"SPU")
+  end
+  SPU.ZVMExtensions = extstr
+end
+usermessage.Hook("wire_spu_extensions", SPU_SetExtensions)
 
 
 
@@ -105,6 +118,7 @@ function ENT:Initialize()
   self.VM.CPUVER  = 1.0 -- Beta SPU by default
   self.VM.CPUTYPE = 2 -- ZSPU
   self.ChipType   = 0
+  self.VM.Extensions = CPULib:FromExtensionString(self.ZVMExtensions,"SPU")
 
   -- Create fake sound sources
   self.SoundSources = {}

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -197,6 +197,7 @@ function ENT:BuildDupeInfo()
   info.ChipType = self.ChipType
   info.Memory = {}
   info.ZVMExtensions = self.ZVMExtensions
+  self:SetExtensionLoadOrder(self.ZVMExtensions)
 
   for address = 0,self.RAMSize-1 do
     if self.Memory[address] and (self.Memory[address] ~= 0) then info.Memory[address] = self.Memory[address] end

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -103,6 +103,18 @@ function ENT:SetMemoryModel(model,initial)
   end
 end
 
+function ENT:SetExtensionLoadOrder(extstr)
+  self.ZVMExtensions = extstr
+  timer.Simple(0.1+math.random()*0.3,
+  function()
+    if not self:IsValid() then return end
+
+    umsg.Start("wire_spu_extensions")
+      umsg.Long(self:EntIndex())
+      umsg.String(self.ZVMExtensions)
+    umsg.End()
+  end)
+end
 
 --------------------------------------------------------------------------------
 -- Resend all SPU cache to newly spawned player
@@ -184,6 +196,7 @@ function ENT:BuildDupeInfo()
   info.RAMSize = self.RAMSize
   info.ChipType = self.ChipType
   info.Memory = {}
+  info.ZVMExtensions = self.ZVMExtensions
 
   for address = 0,self.RAMSize-1 do
     if self.Memory[address] and (self.Memory[address] ~= 0) then info.Memory[address] = self.Memory[address] end
@@ -203,6 +216,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
   self.RAMSize  = math.Clamp(info.RAMSize or 65536, 0, 2097152)
   self.ChipType = info.ChipType or 0
   self.Memory = {}
+  self.ZVMExtensions = info.ZVMExtensions
 
   for address = 0,self.RAMSize-1 do
     if info.Memory[address] then self.Memory[address] = tonumber(info.Memory[address]) or 0 end

--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -145,7 +145,12 @@ end
 
 --------------------------------------------------------------------------------
 -- Emit a code byte to the output stream
-function HCOMP:WriteByte(byte,block)
+function HCOMP:WriteByte(byte,block,negate)
+  -- hack to allow normal opcode calcs to work on negative opcodes
+  if negate then
+    byte = byte * -1
+  end
+
   if self.WriteByteCallback then
     self.WriteByteCallback(self.WriteByteCaller,self.WritePointer,byte)
   end

--- a/lua/wire/client/hlzasm/hc_opcodes.lua
+++ b/lua/wire/client/hlzasm/hc_opcodes.lua
@@ -82,7 +82,7 @@ local function CreateInstructions(indexes)
   buildWritesFirstLookup(newInstructions)
   buildOpLookupTable(newInstructions)
   buildDeprecatedLookupTable(newInstructions)
-  HCOMP:CreateTokenizerOpcodes(newInstructions)
+  HCOMP:RegenerateTokenizerOpcodes()
 end
 
 table.insert(CPULib.RemoveInstructionHooks,RemoveInstructions)

--- a/lua/wire/client/hlzasm/hc_opcodes.lua
+++ b/lua/wire/client/hlzasm/hc_opcodes.lua
@@ -10,34 +10,80 @@
 --------------------------------------------------------------------------------
 -- Initialize opcode count lookup table
 HCOMP.OperandCount = {}
-for _,instruction in pairs(CPULib.InstructionTable) do
-  HCOMP.OperandCount[instruction.Opcode] = instruction.OperandCount
+
+local function buildMainLookup(instructions)
+  for _,instruction in pairs(instructions) do
+    HCOMP.OperandCount[instruction.Opcode] = instruction.OperandCount
+  end
 end
 
 -- Initialize table of single-operand instructions which write 1st operand
 HCOMP.OpcodeWritesOperand = {}
-for _,instruction in pairs(CPULib.InstructionTable) do
-  if instruction.WritesFirstOperand and (instruction.Mnemonic ~= "RESERVED") then
-    HCOMP.OpcodeWritesOperand[string.lower(instruction.Mnemonic)] = true
+
+local function buildWritesFirstLookup(instructions)
+for _,instruction in pairs(instructions) do
+    if instruction.WritesFirstOperand and (instruction.Mnemonic ~= "RESERVED") then
+      HCOMP.OpcodeWritesOperand[string.lower(instruction.Mnemonic)] = true
+    end
   end
 end
 
 -- Initialize opcode number lookup table
 HCOMP.OpcodeNumber = {}
-for _,instruction in pairs(CPULib.InstructionTable) do
-  if instruction.Mnemonic ~= "RESERVED" then
-    HCOMP.OpcodeNumber[string.lower(instruction.Mnemonic)] = instruction.Opcode
+
+local function buildOpLookupTable(instructions)
+  for _,instruction in pairs(instructions) do
+    if instruction.Mnemonic ~= "RESERVED" then
+      HCOMP.OpcodeNumber[string.lower(instruction.Mnemonic)] = instruction.Opcode
+    end
   end
 end
 
 -- Initialize list of obsolete/old opcodes
 HCOMP.OpcodeObsolete = {}
 HCOMP.OpcodeOld = {}
-for _,instruction in pairs(CPULib.InstructionTable) do
-  if instruction.Obsolete and (instruction.Mnemonic ~= "RESERVED") then
-    HCOMP.OpcodeObsolete[string.lower(instruction.Mnemonic)] = true
-  end
-  if instruction.Old and (instruction.Mnemonic ~= "RESERVED") then
-    HCOMP.OpcodeOld[string.lower(instruction.Mnemonic)] = string.lower(instruction.Reference)
+
+local function buildDeprecatedLookupTable(instructions)
+  for _,instruction in pairs(instructions) do
+    if instruction.Obsolete and (instruction.Mnemonic ~= "RESERVED") then
+      HCOMP.OpcodeObsolete[string.lower(instruction.Mnemonic)] = true
+    end
+    if instruction.Old and (instruction.Mnemonic ~= "RESERVED") then
+      HCOMP.OpcodeOld[string.lower(instruction.Mnemonic)] = string.lower(instruction.Reference)
+    end
   end
 end
+
+buildMainLookup(CPULib.InstructionTable)
+buildWritesFirstLookup(CPULib.InstructionTable)
+buildOpLookupTable(CPULib.InstructionTable)
+buildDeprecatedLookupTable(CPULib.InstructionTable)
+
+local function RemoveInstructions(indexes)
+  for _, inst in ipairs(indexes) do
+    local instName = string.lower(CPULib.InstructionTable[inst].Mnemonic)
+    HCOMP.OperandCount[CPULib.InstructionTable[inst].Opcode] = nil
+    HCOMP.OpcodeWritesOperand[instName] = nil
+    HCOMP.OpcodeNumber[instName] = nil
+    HCOMP.OpcodeOld[instName] = nil
+    HCOMP.OpcodeObsolete[instName] = nil
+  end
+  HCOMP:RemoveTokenizerOpcodes(indexes)
+end
+
+local function CreateInstructions(indexes)
+  -- build a small table mirroring instructiontable to reuse the above functions
+  local newInstructions = {}
+  for _,inst in ipairs(indexes) do
+    table.insert(newInstructions,CPULib.InstructionTable[inst])
+  end
+  PrintTable(newInstructions)
+  buildMainLookup(newInstructions)
+  buildWritesFirstLookup(newInstructions)
+  buildOpLookupTable(newInstructions)
+  buildDeprecatedLookupTable(newInstructions)
+  HCOMP:CreateTokenizerOpcodes(newInstructions)
+end
+
+table.insert(CPULib.RemoveInstructionHooks,RemoveInstructions)
+table.insert(CPULib.CreateInstructionHooks,CreateInstructions)

--- a/lua/wire/client/hlzasm/hc_opcodes.lua
+++ b/lua/wire/client/hlzasm/hc_opcodes.lua
@@ -77,7 +77,6 @@ local function CreateInstructions(indexes)
   for _,inst in ipairs(indexes) do
     table.insert(newInstructions,CPULib.InstructionTable[inst])
   end
-  PrintTable(newInstructions)
   buildMainLookup(newInstructions)
   buildWritesFirstLookup(newInstructions)
   buildOpLookupTable(newInstructions)

--- a/lua/wire/client/hlzasm/hc_output.lua
+++ b/lua/wire/client/hlzasm/hc_output.lua
@@ -604,7 +604,7 @@ function HCOMP:WriteBlock(block)
       return
     end
     local Opcode,RM = self.OpcodeNumber[block.Opcode],nil
-    local negativeOp = Opcode < 0
+    local negativeOp = Opcode and Opcode < 0
     if negativeOp then
       Opcode = Opcode*-1
     end

--- a/lua/wire/client/hlzasm/hc_output.lua
+++ b/lua/wire/client/hlzasm/hc_output.lua
@@ -604,7 +604,10 @@ function HCOMP:WriteBlock(block)
       return
     end
     local Opcode,RM = self.OpcodeNumber[block.Opcode],nil
-
+    local negativeOp = Opcode < 0
+    if negativeOp then
+      Opcode = Opcode*-1
+    end
     -- Generate RM if more than 1 operand
     if #block.Operands > 0 then
       RM = self:OperandRM(block.Operands[1],block)
@@ -617,7 +620,7 @@ function HCOMP:WriteBlock(block)
 
     if not self.Settings.FixedSizeOutput then -- Variable-size instructions
       -- Write opcode
-      self:WriteByte(Opcode,block)
+      self:WriteByte(Opcode,block,negativeOp)
       -- Write RM
       if RM then self:WriteByte(RM,block) end
 
@@ -630,7 +633,7 @@ function HCOMP:WriteBlock(block)
       if (#block.Operands > 1) and (block.Operands[2].Value) then self:WriteByte(block.Operands[2].Value,block) end
     else -- Fixed-size instructions
       -- Write opcode
-      self:WriteByte(Opcode + 2000,block)
+      self:WriteByte(Opcode + 2000,block,negativeOp)
 
       -- Write RM
       self:WriteByte(RM or 0,block)

--- a/lua/wire/client/hlzasm/hc_syntax.lua
+++ b/lua/wire/client/hlzasm/hc_syntax.lua
@@ -32,7 +32,7 @@ function HCOMP:Opcode() local TOKEN,TOKENSET = self.TOKEN,self.TOKENSET
   local opcodeName = self.TokenData
   local opcodeNo = self.OpcodeNumber[self.TokenData]
   local operandCount = self.OperandCount[opcodeNo]
-
+  print(opcodeName, opcodeNo, operandCount)
   -- Check if opcode is obsolete or old
   if self.OpcodeObsolete[opcodeName] then
     self:Warning("Instruction \""..opcodeName.."\" is obsolete")

--- a/lua/wire/client/hlzasm/hc_syntax.lua
+++ b/lua/wire/client/hlzasm/hc_syntax.lua
@@ -32,7 +32,6 @@ function HCOMP:Opcode() local TOKEN,TOKENSET = self.TOKEN,self.TOKENSET
   local opcodeName = self.TokenData
   local opcodeNo = self.OpcodeNumber[self.TokenData]
   local operandCount = self.OperandCount[opcodeNo]
-  print(opcodeName, opcodeNo, operandCount)
   -- Check if opcode is obsolete or old
   if self.OpcodeObsolete[opcodeName] then
     self:Warning("Instruction \""..opcodeName.."\" is obsolete")

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -211,7 +211,6 @@ for symID,symList in pairs(HCOMP.TOKEN_TEXT) do
   end
 end
 
-
 -- Add opcodes to the lookup table
 for _,languageName in pairs(HCOMP.TOKEN_TEXT["OPCODE"][1]) do
   HCOMP.PARSER_LOOKUP[languageName] = HCOMP.PARSER_LOOKUP[languageName] or {}
@@ -220,6 +219,27 @@ for _,languageName in pairs(HCOMP.TOKEN_TEXT["OPCODE"][1]) do
   end
 end
 
+
+function HCOMP:RemoveTokenizerOpcodes(indexes)
+  -- Remove opcodes from the lookup table
+  for _,languageName in pairs(self.TOKEN_TEXT["OPCODE"][1]) do
+    self.PARSER_LOOKUP[languageName] = self.PARSER_LOOKUP[languageName] or {}
+    for _,index in ipairs(indexes) do
+      self.PARSER_LOOKUP[languageName][string.upper(CPULib.InstructionTable[index].Mnemonic)] = nil
+    end
+  end
+end
+
+function HCOMP:CreateTokenizerOpcodes(indexes)
+  -- Add opcodes to the lookup table from list of indexes
+  for _,languageName in pairs(self.TOKEN_TEXT["OPCODE"][1]) do
+    self.PARSER_LOOKUP[languageName] = self.PARSER_LOOKUP[languageName] or {}
+    for _,index in ipairs(indexes) do
+      print(CPULib.InstructionTable[index].Mnemonic)
+      self.PARSER_LOOKUP[languageName][string.upper(CPULib.InstructionTable[index].Mnemonic)] = { CPULib.InstructionTable[index].Mnemonic, HCOMP.TOKEN.OPCODE }
+    end
+  end
+end
 
 
 

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -211,13 +211,7 @@ for symID,symList in pairs(HCOMP.TOKEN_TEXT) do
   end
 end
 
--- Add opcodes to the lookup table
-for _,languageName in pairs(HCOMP.TOKEN_TEXT["OPCODE"][1]) do
-  HCOMP.PARSER_LOOKUP[languageName] = HCOMP.PARSER_LOOKUP[languageName] or {}
-  for opcodeName,opcodeNo in pairs(HCOMP.OpcodeNumber) do
-    HCOMP.PARSER_LOOKUP[languageName][string.upper(opcodeName)] = { opcodeName, HCOMP.TOKEN.OPCODE }
-  end
-end
+
 
 
 function HCOMP:RemoveTokenizerOpcodes(indexes)
@@ -230,18 +224,17 @@ function HCOMP:RemoveTokenizerOpcodes(indexes)
   end
 end
 
-function HCOMP:CreateTokenizerOpcodes(indexes)
-  -- Add opcodes to the lookup table from list of indexes
-  for _,languageName in pairs(self.TOKEN_TEXT["OPCODE"][1]) do
-    self.PARSER_LOOKUP[languageName] = self.PARSER_LOOKUP[languageName] or {}
-    for _,index in ipairs(indexes) do
-      print(CPULib.InstructionTable[index].Mnemonic)
-      self.PARSER_LOOKUP[languageName][string.upper(CPULib.InstructionTable[index].Mnemonic)] = { CPULib.InstructionTable[index].Mnemonic, HCOMP.TOKEN.OPCODE }
+function HCOMP:RegenerateTokenizerOpcodes()
+-- Add opcodes to the lookup table
+for _,languageName in pairs(HCOMP.TOKEN_TEXT["OPCODE"][1]) do
+    HCOMP.PARSER_LOOKUP[languageName] = HCOMP.PARSER_LOOKUP[languageName] or {}
+    for opcodeName,opcodeNo in pairs(HCOMP.OpcodeNumber) do
+      HCOMP.PARSER_LOOKUP[languageName][string.upper(opcodeName)] = { opcodeName, HCOMP.TOKEN.OPCODE }
     end
   end
 end
 
-
+HCOMP:RegenerateTokenizerOpcodes()
 
 --------------------------------------------------------------------------------
 -- Skip a single file in input

--- a/lua/wire/client/text_editor/modes/zcpu.lua
+++ b/lua/wire/client/text_editor/modes/zcpu.lua
@@ -60,6 +60,24 @@ for k,v in pairs(CPULib.InstructionTable) do
   end
 end
 
+local function RemoveInstructions(indexes)
+  for _,v in ipairs(indexes) do
+    opcodeTable[CPULib.InstructionTable[v].Mnemonic] = nil
+  end
+end
+
+local function CreateInstructions(indexes)
+  for _,v in ipairs(indexes) do
+    local inst = CPULib.InstructionTable[v]
+    if inst.Mnemonic ~= "RESERVED" then
+      opcodeTable[inst.Mnemonic] = true
+    end
+  end
+end
+
+table.insert(CPULib.RemoveInstructionHooks,RemoveInstructions)
+table.insert(CPULib.CreateInstructionHooks,CreateInstructions)
+
 -- Build lookup table for keywords
 local keywordsList = {
   "GOTO","FOR","IF","ELSE","WHILE","DO","SWITCH","CASE","CONST","RETURN","BREAK",

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -899,6 +899,27 @@ function CPULib:RebuildExtendedInstructions()
   end
 end
 
+function CPULib:ToExtensionString(exttable)
+  local ext_str = ""
+  for _,ext in ipairs(exttable) do
+    ext_str = ext_str .. ext .. ';'
+  end
+  return ext_str
+end
+
+function CPULib:FromExtensionString(extstr,platform)
+  local extensions = {}
+  -- only available extensions are loaded
+  if not extstr then return {} end
+  for ext in string.gmatch(extstr or "","([^;]*);") do
+    print("extracted "..ext)
+    if CPULib.Extensions[platform] and CPULib.Extensions[platform][ext] then
+      table.insert(extensions,ext)
+    end
+  end
+  return extensions
+end
+
 function CPULib:LoadExtensionOrder(extensions, platform)
   self.ExtensionOrder[platform] = extensions
   self:RebuildExtendedInstructions()
@@ -912,11 +933,14 @@ function CPULib:LoadExtensions(VM, platform)
     return false
   end
   local curInstruction = -1
+  print("vm ext: ")
+  PrintTable(VM.Extensions)
   for _, name in pairs(VM.Extensions) do
     if self.Extensions[platform][name] then
       -- The actual load order is the order that it's in for the VM.
       for _,instr in ipairs(self.Extensions[platform][name].Instructions) do
-        VM.OperandCount[curInstruction] = instr.OpCount
+        print(instr.Name .. " added")
+        VM.OperandCount[curInstruction] = instr.Operands
         VM.OpcodeTable[curInstruction] = instr.OpFunc
         curInstruction = curInstruction - 1
       end

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -888,7 +888,7 @@ function CPULib:RebuildExtendedInstructions()
     local curOpcode = -1
     for _,extension in ipairs(platform) do
       for _,i in ipairs(self.Extensions[platname][extension].Instructions) do
-        Entry(platname,curOpcode,i.Name,i.Operands,i.Version,self.ParseFlagArray(i.Flags),i.Op1Name,i.Op2Name,i.Description)
+        Entry(platname,curOpcode,i.Name,i.Operands,i.Version,self:ParseFlagArray(i.Flags),i.Op1Name,i.Op2Name,i.Description)
         table.insert(self.ExtendedInstructions,#CPULib.InstructionTable)
         curOpcode = curOpcode - 1
       end
@@ -912,7 +912,6 @@ function CPULib:FromExtensionString(extstr,platform)
   -- only available extensions are loaded
   if not extstr then return {} end
   for ext in string.gmatch(extstr or "","([^;]*);") do
-    print("extracted "..ext)
     if CPULib.Extensions[platform] and CPULib.Extensions[platform][ext] then
       table.insert(extensions,ext)
     end
@@ -933,13 +932,10 @@ function CPULib:LoadExtensions(VM, platform)
     return false
   end
   local curInstruction = -1
-  print("vm ext: ")
-  PrintTable(VM.Extensions)
   for _, name in pairs(VM.Extensions) do
     if self.Extensions[platform][name] then
       -- The actual load order is the order that it's in for the VM.
       for _,instr in ipairs(self.Extensions[platform][name].Instructions) do
-        print(instr.Name .. " added")
         VM.OperandCount[curInstruction] = instr.Operands
         VM.OpcodeTable[curInstruction] = instr.OpFunc
         curInstruction = curInstruction - 1

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -936,13 +936,16 @@ function CPULib:LoadExtensions(VM, platform)
     if self.Extensions[platform][name] then
       -- The actual load order is the order that it's in for the VM.
       for _,instr in ipairs(self.Extensions[platform][name].Instructions) do
-        VM.OperandCount[curInstruction] = instr.Operands
+        VM.ExtOperandCount[curInstruction*-1] = instr.Operands
+        if instr.Privileged then
+          VM.ExtOperandRunLevel[curInstruction*-1] = 0
+        end
         VM.OpcodeTable[curInstruction] = instr.OpFunc
         curInstruction = curInstruction - 1
       end
     else
-      -- return true on err, false/nothing otherwise
-      print(name .. ' unavailable!!!')
+      -- return name of missing extension on error
+      return name
     end
   end
 end

--- a/lua/wire/cpulib_example_extension.lua
+++ b/lua/wire/cpulib_example_extension.lua
@@ -1,0 +1,21 @@
+if not CPULib then
+	include("wire/cpulib.lua")	
+end
+
+local myGPUExtension = {
+	Platform = "GPU",
+	Instructions = {{
+		Name = "EXT_TEST",
+		Operands = 0,
+		Version = 0.42,
+		Flags = {},
+		Op1Name = "",
+		Op2Name = "",
+		Description = "Basic test instruction, added by an extension.",
+		["OpFunc"] = function(self)
+			self:Dyn_Emit("print('test succeeded! Woohoo')")
+		end
+	}}
+}
+
+CPULib:RegisterExtension("basic_test", myGPUExtension)

--- a/lua/wire/cpulib_example_extension.lua
+++ b/lua/wire/cpulib_example_extension.lua
@@ -2,6 +2,51 @@ if not CPULib then
 	include("wire/cpulib.lua")	
 end
 
+-- Returns false if extension is already created/registered
+local myCPUExtension = CPULib:CreateExtension("cpu_test","CPU")
+
+if myCPUExtension then
+	-- Creates a function using the raw ZVM API, make your function similar to the ones in zvm_opcodes.lua
+	-- Args:
+	-- Name, Operands, OpFunc, Flags, Documentation (missing entries are autofilled)
+	myCPUExtension:RegisterInstruction(
+		"CPU_TEST1",
+		1,
+		function(self)
+			self:Dyn_EmitOperand("42")
+		end,
+		{"W1"},
+		{
+			Version = 0.42,
+			Description = "Sets Register X to constant 42"
+		}
+	)
+
+	-- Example of how to reassign the value of the first operand used to itself divided by 24
+	local function myLuaInstruction(VM,Operands)
+		if Operands[1] > 49 or Operands[1] < 40 then
+			-- Call interrupt 5 with argument showing the value of Operand 1
+			-- Error code to user would look something like 5.039 if Operand 1 = 39
+			return 5, Operands[1]
+		end
+		Operands[1] = Operands[1]/24
+	end
+
+	-- Works like RegisterInstruction but it will call the passed lua function.
+	-- Args:
+	-- Name, Operands, LuaFunc, Flags, Documentation (missing entries are autofilled)
+	myCPUExtension:InstructionFromLuaFunc(
+		"CPU_TEST2",
+		1,
+		myLuaInstruction,
+		{"W1"},
+		{
+			Version = 0.42,
+			Description = "Divides Register X by constant 24, Produces Error 5 if not between 40 and 49"
+		}
+	)
+end
+-- Below is the structure of the actual extension, incase you'd rather register them yourself.
 local myGPUExtension = {
 	Platform = "GPU",
 	Instructions = {{
@@ -33,69 +78,4 @@ local myGPUExtension = {
 	}}
 }
 
-local myCPUExtension = {
-	Platform = "CPU",
-	Instructions = {{
-		Name = "CPU_TEST1",
-		Operands = 1,
-		Version = 0.42,
-		Flags = {"W1"}, -- writes first operand
-		Op1Name = "X",
-		Op2Name = "",
-		Description = "Sets Register X to constant 42",
-		["OpFunc"] = function(self)
-			-- The end value of the code in Dyn_EmitOperand will be assigned
-			-- to the first/left hand register used in this instruction
-			self:Dyn_EmitOperand("42")
-		end
-	},
-	{
-		Name = "CPU_TEST2",
-		Operands = 1,
-		Version = 0.42,
-		Flags = {"W1"}, -- writes first operand
-		Op1Name = "X",
-		Op2Name = "",
-		Description = "Divides Register X by constant 24",
-		["OpFunc"] = function(self)
-			-- $1 and $2 refer to the first, and second operands of the instruction respectively
-			self:Dyn_EmitOperand("$1/24")
-		end
-	}}
-}
-
-
-local mySPUExtension = {
-	Platform = "SPU",
-	Instructions = {{
-		Name = "SPU_TEST1",
-		Operands = 1,
-		Version = 0.42,
-		Flags = {"W1"}, -- writes first operand
-		Op1Name = "X",
-		Op2Name = "",
-		Description = "Sets Register X to constant 42",
-		["OpFunc"] = function(self)
-			-- The end value of the code in Dyn_EmitOperand will be assigned
-			-- to the first/left hand register used in this instruction
-			self:Dyn_EmitOperand("42")
-		end
-	},
-	{
-		Name = "SPU_TEST2",
-		Operands = 1,
-		Version = 0.42,
-		Flags = {"W1"}, -- writes first operand
-		Op1Name = "X",
-		Op2Name = "",
-		Description = "Divides Register X by constant 24",
-		["OpFunc"] = function(self)
-			-- $1 and $2 refer to the first, and second operands of the instruction respectively
-			self:Dyn_EmitOperand("$1/24")
-		end
-	}}
-}
-
--- CPULib:RegisterExtension("gpu_test", myGPUExtension)
--- CPULib:RegisterExtension("spu_test", mySPUExtension)
--- CPULib:RegisterExtension("cpu_test", myCPUExtension)
+CPULib:RegisterExtension("gpu_test", myGPUExtension)

--- a/lua/wire/cpulib_example_extension.lua
+++ b/lua/wire/cpulib_example_extension.lua
@@ -5,15 +5,30 @@ end
 local myGPUExtension = {
 	Platform = "GPU",
 	Instructions = {{
-		Name = "EXT_TEST",
-		Operands = 0,
+		Name = "GPU_TEST1",
+		Operands = 1,
 		Version = 0.42,
-		Flags = {},
-		Op1Name = "",
+		Flags = {"W1"}, -- writes first operand
+		Op1Name = "X",
 		Op2Name = "",
-		Description = "Basic test instruction, added by an extension.",
+		Description = "Sets Register X to constant 42",
 		["OpFunc"] = function(self)
-			self:Dyn_Emit("print('test succeeded! Woohoo')")
+			-- The end value of the code in Dyn_EmitOperand will be assigned
+			-- to the first/left hand register used in this instruction
+			self:Dyn_EmitOperand("42")
+		end
+	},
+	{
+		Name = "GPU_TEST2",
+		Operands = 1,
+		Version = 0.42,
+		Flags = {"W1"}, -- writes first operand
+		Op1Name = "X",
+		Op2Name = "",
+		Description = "Divides Register X by constant 24",
+		["OpFunc"] = function(self)
+			-- $1 and $2 refer to the first, and second operands of the instruction respectively
+			self:Dyn_EmitOperand("$1/24")
 		end
 	}}
 }
@@ -31,7 +46,6 @@ local myCPUExtension = {
 		["OpFunc"] = function(self)
 			-- The end value of the code in Dyn_EmitOperand will be assigned
 			-- to the first/left hand register used in this instruction
-			self:Dyn_Emit("print('cpu_test $1')")
 			self:Dyn_EmitOperand("42")
 		end
 	},
@@ -42,15 +56,46 @@ local myCPUExtension = {
 		Flags = {"W1"}, -- writes first operand
 		Op1Name = "X",
 		Op2Name = "",
-		Description = "Sets Register X to constant 24",
+		Description = "Divides Register X by constant 24",
 		["OpFunc"] = function(self)
-			-- The end value of the code in Dyn_EmitOperand will be assigned
-			-- to the first/left hand register used in this instruction
-			self:Dyn_EmitOperand("24")
+			-- $1 and $2 refer to the first, and second operands of the instruction respectively
+			self:Dyn_EmitOperand("$1/24")
 		end
 	}}
 }
 
 
-CPULib:RegisterExtension("basic_test", myGPUExtension)
+local mySPUExtension = {
+	Platform = "SPU",
+	Instructions = {{
+		Name = "SPU_TEST1",
+		Operands = 1,
+		Version = 0.42,
+		Flags = {"W1"}, -- writes first operand
+		Op1Name = "X",
+		Op2Name = "",
+		Description = "Sets Register X to constant 42",
+		["OpFunc"] = function(self)
+			-- The end value of the code in Dyn_EmitOperand will be assigned
+			-- to the first/left hand register used in this instruction
+			self:Dyn_EmitOperand("42")
+		end
+	},
+	{
+		Name = "SPU_TEST2",
+		Operands = 1,
+		Version = 0.42,
+		Flags = {"W1"}, -- writes first operand
+		Op1Name = "X",
+		Op2Name = "",
+		Description = "Divides Register X by constant 24",
+		["OpFunc"] = function(self)
+			-- $1 and $2 refer to the first, and second operands of the instruction respectively
+			self:Dyn_EmitOperand("$1/24")
+		end
+	}}
+}
+
+CPULib:RegisterExtension("gpu_test", myGPUExtension)
+CPULib:RegisterExtension("spu_test", mySPUExtension)
 CPULib:RegisterExtension("cpu_test", myCPUExtension)

--- a/lua/wire/cpulib_example_extension.lua
+++ b/lua/wire/cpulib_example_extension.lua
@@ -96,6 +96,6 @@ local mySPUExtension = {
 	}}
 }
 
-CPULib:RegisterExtension("gpu_test", myGPUExtension)
-CPULib:RegisterExtension("spu_test", mySPUExtension)
-CPULib:RegisterExtension("cpu_test", myCPUExtension)
+-- CPULib:RegisterExtension("gpu_test", myGPUExtension)
+-- CPULib:RegisterExtension("spu_test", mySPUExtension)
+-- CPULib:RegisterExtension("cpu_test", myCPUExtension)

--- a/lua/wire/cpulib_example_extension.lua
+++ b/lua/wire/cpulib_example_extension.lua
@@ -18,4 +18,39 @@ local myGPUExtension = {
 	}}
 }
 
+local myCPUExtension = {
+	Platform = "CPU",
+	Instructions = {{
+		Name = "CPU_TEST1",
+		Operands = 1,
+		Version = 0.42,
+		Flags = {"W1"}, -- writes first operand
+		Op1Name = "X",
+		Op2Name = "",
+		Description = "Sets Register X to constant 42",
+		["OpFunc"] = function(self)
+			-- The end value of the code in Dyn_EmitOperand will be assigned
+			-- to the first/left hand register used in this instruction
+			self:Dyn_Emit("print('cpu_test $1')")
+			self:Dyn_EmitOperand("42")
+		end
+	},
+	{
+		Name = "CPU_TEST2",
+		Operands = 1,
+		Version = 0.42,
+		Flags = {"W1"}, -- writes first operand
+		Op1Name = "X",
+		Op2Name = "",
+		Description = "Sets Register X to constant 24",
+		["OpFunc"] = function(self)
+			-- The end value of the code in Dyn_EmitOperand will be assigned
+			-- to the first/left hand register used in this instruction
+			self:Dyn_EmitOperand("24")
+		end
+	}}
+}
+
+
 CPULib:RegisterExtension("basic_test", myGPUExtension)
+CPULib:RegisterExtension("cpu_test", myCPUExtension)

--- a/lua/wire/stools/cpu.lua
+++ b/lua/wire/stools/cpu.lua
@@ -19,6 +19,7 @@ TOOL.ClientConVar = {
   model             = "models/cheeze/wires/cpu.mdl",
   filename          = "",
   memorymodel       = "64krom",
+  extensions        = ""
 }
 
 if CLIENT then

--- a/lua/wire/stools/cpu.lua
+++ b/lua/wire/stools/cpu.lua
@@ -215,11 +215,13 @@ if CLIENT then
     ExtensionPanel:SetSize(235,200)
     DisabledExtensionPanel:SetSize(235,200)
 
-    for k,_ in pairs(CPULib.Extensions["CPU"]) do
-      if enabledExtensionLookup[k] then
-        ExtensionPanel:AddLine(k)
-      else
-        DisabledExtensionPanel:AddLine(k)
+    if CPULib.Extensions["CPU"] then
+      for k,_ in pairs(CPULib.Extensions["CPU"]) do
+        if enabledExtensionLookup[k] then
+          ExtensionPanel:AddLine(k)
+        else
+          DisabledExtensionPanel:AddLine(k)
+        end
       end
     end
 
@@ -246,6 +248,9 @@ if CLIENT then
 
     panel:AddItem(ExtensionPanel)
     panel:AddItem(DisabledExtensionPanel)
+    -- Reload the extensions at least once to make sure users don't have to touch the list
+    -- in order to use extensions on first opening of the tool menu
+    ReloadExtensions()
 
   end
 

--- a/lua/wire/stools/gpu.lua
+++ b/lua/wire/stools/gpu.lua
@@ -58,6 +58,7 @@ if SERVER then
   function TOOL:MakeEnt(ply, model, Ang, trace)
     local ent = WireLib.MakeWireEnt(ply, {Class = self.WireClass, Pos=trace.HitPos, Angle=Ang, Model=model})
     ent:SetMemoryModel(self:GetClientInfo("memorymodel"))
+    ent:SetExtensionLoadOrder(self:GetClientInfo("extensions"))
     self:LeftClick_Update(trace)
     return ent
   end
@@ -179,7 +180,8 @@ if CLIENT then
 
     local enabledExtensionOrder = {}
     local enabledExtensionLookup = {}
-    for ext in string.gmatch(wire_gpu_extensions or "","([^;]*);") do
+    local extensionConvar = GetConVar("wire_gpu_extensions")
+    for ext in string.gmatch(extensionConvar:GetString() or "","([^;]*);") do
       if CPULib.Extensions["GPU"] and CPULib.Extensions["GPU"][ext] then
         enabledExtensionLookup[ext] = true
         table.insert(enabledExtensionOrder,ext)
@@ -193,7 +195,7 @@ if CLIENT then
     ExtensionPanel:SetSize(470,200)
     DisabledExtensionPanel:SetSize(235,200)
 
-    PrintTable(CPULib.Extensions["GPU"])
+    -- PrintTable(CPULib.Extensions["GPU"])
 
     for k,_ in pairs(CPULib.Extensions["GPU"]) do
       if enabledExtensionLookup[k] then
@@ -208,6 +210,7 @@ if CLIENT then
       for _,line in pairs(ExtensionPanel:GetLines()) do
         table.insert(extensions,line:GetValue(1))
       end
+      extensionConvar:SetString(CPULib:ToExtensionString(extensions))
       CPULib:LoadExtensionOrder(extensions,"GPU")
     end
 

--- a/lua/wire/stools/gpu.lua
+++ b/lua/wire/stools/gpu.lua
@@ -192,10 +192,8 @@ if CLIENT then
     local DisabledExtensionPanel = vgui.Create("DListView")
     ExtensionPanel:AddColumn("Enabled Extensions")
     DisabledExtensionPanel:AddColumn("Disabled Extensions")
-    ExtensionPanel:SetSize(470,200)
+    ExtensionPanel:SetSize(235,200)
     DisabledExtensionPanel:SetSize(235,200)
-
-    -- PrintTable(CPULib.Extensions["GPU"])
 
     for k,_ in pairs(CPULib.Extensions["GPU"]) do
       if enabledExtensionLookup[k] then

--- a/lua/wire/stools/gpu.lua
+++ b/lua/wire/stools/gpu.lua
@@ -194,12 +194,13 @@ if CLIENT then
     DisabledExtensionPanel:AddColumn("Disabled Extensions")
     ExtensionPanel:SetSize(235,200)
     DisabledExtensionPanel:SetSize(235,200)
-
-    for k,_ in pairs(CPULib.Extensions["GPU"]) do
-      if enabledExtensionLookup[k] then
-        ExtensionPanel:AddLine(k)
-      else
-        DisabledExtensionPanel:AddLine(k)
+    if CPULib.Extensions["GPU"] then
+      for k,_ in pairs(CPULib.Extensions["GPU"]) do
+        if enabledExtensionLookup[k] then
+          ExtensionPanel:AddLine(k)
+        else
+          DisabledExtensionPanel:AddLine(k)
+        end
       end
     end
 
@@ -226,7 +227,9 @@ if CLIENT then
 
     panel:AddItem(ExtensionPanel)
     panel:AddItem(DisabledExtensionPanel)
-
+    -- Reload the extensions at least once to make sure users don't have to touch the list
+    -- in order to use extensions on first opening of the tool menu
+    ReloadExtensions()
 
   end
 

--- a/lua/wire/stools/gpu.lua
+++ b/lua/wire/stools/gpu.lua
@@ -18,6 +18,7 @@ TOOL.ClientConVar = {
   model             = "models/cheeze/wires/cpu.mdl",
   filename          = "",
   memorymodel       = "64k",
+  extensions        = ""
 }
 
 if CLIENT then
@@ -176,14 +177,56 @@ if CLIENT then
     })
     panel:AddControl("Label", {Text = "Memory model selects GPU memory size and its operation mode"})
 
+    local enabledExtensionOrder = {}
+    local enabledExtensionLookup = {}
+    for ext in string.gmatch(wire_gpu_extensions or "","([^;]*);") do
+      if CPULib.Extensions["GPU"] and CPULib.Extensions["GPU"][ext] then
+        enabledExtensionLookup[ext] = true
+        table.insert(enabledExtensionOrder,ext)
+      end
+    end
 
-    ----------------------------------------------------------------------------
---    panel:AddControl("Button", {
---      Text = "ZGPU documentation (online)"
---    })
---    panel:AddControl("Label", {
---      Text = "Loads online GPU documentation and tutorials"
---    })
+    local ExtensionPanel = vgui.Create("DListView")
+    local DisabledExtensionPanel = vgui.Create("DListView")
+    ExtensionPanel:AddColumn("Enabled Extensions")
+    DisabledExtensionPanel:AddColumn("Disabled Extensions")
+    ExtensionPanel:SetSize(470,200)
+    DisabledExtensionPanel:SetSize(235,200)
+
+    PrintTable(CPULib.Extensions["GPU"])
+
+    for k,_ in pairs(CPULib.Extensions["GPU"]) do
+      if enabledExtensionLookup[k] then
+        ExtensionPanel:AddLine(k)
+      else
+        DisabledExtensionPanel:AddLine(k)
+      end
+    end
+
+    local function ReloadExtensions()
+      local extensions = {}
+      for _,line in pairs(ExtensionPanel:GetLines()) do
+        table.insert(extensions,line:GetValue(1))
+      end
+      CPULib:LoadExtensionOrder(extensions,"GPU")
+    end
+
+    function ExtensionPanel:OnRowSelected(rIndex,row)
+      DisabledExtensionPanel:AddLine(row:GetValue(1))
+      self:RemoveLine(rIndex)
+      ReloadExtensions()
+    end
+
+    function DisabledExtensionPanel:OnRowSelected(rIndex,row)
+      ExtensionPanel:AddLine(row:GetValue(1))
+      self:RemoveLine(rIndex)
+      ReloadExtensions()
+    end
+
+    panel:AddItem(ExtensionPanel)
+    panel:AddItem(DisabledExtensionPanel)
+
+
   end
 
   ------------------------------------------------------------------------------

--- a/lua/wire/stools/spu.lua
+++ b/lua/wire/stools/spu.lua
@@ -16,6 +16,7 @@ WireToolSetup.SetupMax( 7 )
 TOOL.ClientConVar = {
   model             = "models/cheeze/wires/cpu.mdl",
   filename          = "",
+  extensions        = ""
 }
 
 if CLIENT then

--- a/lua/wire/stools/spu.lua
+++ b/lua/wire/stools/spu.lua
@@ -57,6 +57,7 @@ if SERVER then
   function TOOL:MakeEnt(ply, model, Ang, trace)
     local ent = WireLib.MakeWireEnt(ply, {Class = self.WireClass, Pos=trace.HitPos, Angle=Ang, Model=model})
     ent:SetMemoryModel(self:GetClientInfo("memorymodel"))
+    ent:SetExtensionLoadOrder(self:GetClientInfo("extensions"))
     self:LeftClick_Update(trace)
     return ent
   end
@@ -158,6 +159,60 @@ if CLIENT then
     ----------------------------------------------------------------------------
     WireDermaExts.ModelSelect(panel, "wire_spu_model", list.Get("Wire_gate_Models"), 2)
     panel:AddControl("Label", {Text = ""})
+
+    local enabledExtensionOrder = {}
+    local enabledExtensionLookup = {}
+    local extensionConvar = GetConVar("wire_spu_extensions")
+    for ext in string.gmatch(extensionConvar:GetString() or "","([^;]*);") do
+      if CPULib.Extensions["SPU"] and CPULib.Extensions["SPU"][ext] then
+        enabledExtensionLookup[ext] = true
+        table.insert(enabledExtensionOrder,ext)
+      end
+    end
+
+    local ExtensionPanel = vgui.Create("DListView")
+    local DisabledExtensionPanel = vgui.Create("DListView")
+    ExtensionPanel:AddColumn("Enabled Extensions")
+    DisabledExtensionPanel:AddColumn("Disabled Extensions")
+    ExtensionPanel:SetSize(235,200)
+    DisabledExtensionPanel:SetSize(235,200)
+    if CPULib.Extensions["SPU"] then
+      for k,_ in pairs(CPULib.Extensions["SPU"]) do
+        if enabledExtensionLookup[k] then
+          ExtensionPanel:AddLine(k)
+        else
+          DisabledExtensionPanel:AddLine(k)
+        end
+      end
+    end
+
+    local function ReloadExtensions()
+      local extensions = {}
+      for _,line in pairs(ExtensionPanel:GetLines()) do
+        table.insert(extensions,line:GetValue(1))
+      end
+      extensionConvar:SetString(CPULib:ToExtensionString(extensions))
+      CPULib:LoadExtensionOrder(extensions,"SPU")
+    end
+
+    function ExtensionPanel:OnRowSelected(rIndex,row)
+      DisabledExtensionPanel:AddLine(row:GetValue(1))
+      self:RemoveLine(rIndex)
+      ReloadExtensions()
+    end
+
+    function DisabledExtensionPanel:OnRowSelected(rIndex,row)
+      ExtensionPanel:AddLine(row:GetValue(1))
+      self:RemoveLine(rIndex)
+      ReloadExtensions()
+    end
+
+    panel:AddItem(ExtensionPanel)
+    panel:AddItem(DisabledExtensionPanel)
+    -- Reload the extensions at least once to make sure users don't have to touch the list
+    -- in order to use extensions on first opening of the tool menu
+    ReloadExtensions()
+
   end
 
   ------------------------------------------------------------------------------

--- a/lua/wire/zvm/zvm_core.lua
+++ b/lua/wire/zvm/zvm_core.lua
@@ -467,8 +467,8 @@ function ZVM:Precompile_Step()
   local Opcode,RM = self:Precompile_Fetch(),0
   local isFixedSize = false
   local OpCount,OpRunLevel = self.OperandCount,self.OpcodeRunLevel
-  local RealOpcode = Opcode
-  if Opcode < 0 then
+  local negativeOp = Opcode and Opcode < 0
+  if negativeOp then
     OpCount,OpRunLevel = self.ExtOperandCount,self.ExtOpcodeRunLevel
     Opcode = Opcode * - 1
   end
@@ -594,7 +594,11 @@ function ZVM:Precompile_Step()
     end
 
     -- Emit opcode
-    self:Dyn_EmitOpcode(RealOpcode)
+    if negativeOp then
+      self:Dyn_EmitOpcode(Opcode*-1)
+    else
+      self:Dyn_EmitOpcode(Opcode)
+    end
 
     -- Write back the values
     if OpCount[Opcode] and (OpCount[Opcode] > 0) then

--- a/lua/wire/zvm/zvm_core.lua
+++ b/lua/wire/zvm/zvm_core.lua
@@ -81,7 +81,6 @@ end
 --------------------------------------------------------------------------------
 -- Load/fetch operand (by RM)
 function ZVM:Dyn_LoadOperand(OP,RM)
-  print("loadoperand "..OP.." as "..RM)
   if self.OperandReadFunctions[RM] then
     local preEmit
     if self.ReadInvolvedRegisterLookup[RM] and
@@ -148,10 +147,8 @@ end
 --------------------------------------------------------------------------------
 -- Preprocess microcode text (for microcode syntax to work)
 function ZVM:Dyn_PreprocessEmit(text)
-  print('preprocess input ' .. text)
   local preEmit = string.gsub(   text,"$1",self.EmitOperand[1])
         preEmit = string.gsub(preEmit,"$2",self.EmitOperand[2])
-  print('op1 ' .. self.EmitOperand[1])
   return string.gsub(preEmit,"$L","local")
 end
 
@@ -171,7 +168,6 @@ end
 -- Emit operand being set to specific expression
 function ZVM:Dyn_EmitOperand(OP,text,emitNow)
   if not text then
-    print('operand '..OP)
     self.EmitExpression[1] = self:Dyn_PreprocessEmit(OP)
   else
     self.EmitExpression[OP] = self:Dyn_PreprocessEmit(text)
@@ -427,7 +423,6 @@ function ZVM:Precompile_Fetch()
   self.PrecompileXEIP = self.PrecompileXEIP + 1
   self.PrecompileIP = self.PrecompileIP + 1
   self.PrecompileBytes = self.PrecompileBytes + 1
-  print("fetched "..value)
   return value or 0
 end
 

--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -15,7 +15,6 @@ end
 
 
 
-
 -- Initialize runlevel lookup table
 ZVM.OpcodeRunLevel = {}
 for _,instruction in pairs(CPULib.InstructionTable) do
@@ -24,7 +23,10 @@ for _,instruction in pairs(CPULib.InstructionTable) do
   end
 end
 
-
+-- If an opcode is negative(like for extensions), the opcode will be absoluted
+-- and use these lookup tables instead of the primary ones.
+ZVM.ExtOperandCount = {}
+ZVM.ExtOpcodeRunLevel = {}
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Extends CPULib to allow for addons to add new instructions to a ZVM platform on a per-entity basis, determined by the player's load order at entity creation.

The UI to load and unload extensions is available in the tool menu, clicking on an extension will switch it between the two categories
![image](https://github.com/wiremod/wire-cpu/assets/57756830/83376594-b413-4c97-bfa6-651f7d3831cf)

It will only show the available extensions for said tool, you won't see GPU extensions when looking at the CPU tool for example.

The HLZASM compiler & editor are aware of your currently available extended instructions, and can only highlight or compile them while enabled

(extension is enabled)
![image](https://github.com/wiremod/wire-cpu/assets/57756830/c4df9296-4bbf-4bd8-90af-04c7683daadb)


(extension is disabled)
![image](https://github.com/wiremod/wire-cpu/assets/57756830/5d8de0e0-809e-40b7-8241-c49d5534d202)


Compilation/upload is also affected by the player's load order, so keep in mind if the load order differs between player & ent your code may not work correctly.

See [cpu_example_extension.lua](https://github.com/DerelictDrone/wire-cpu/blob/994d4f5489b448604bd1312a5462f45f7ef967b1/lua/wire/cpulib_example_extension.lua) as an example for the structure required to make your own extension.

