### PR TITLE
Sandboxes the ZVM

### DIFF
--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -26,6 +26,11 @@ function ENT:OverrideVM()
     end
   end
 
+  self.VM.Env["surface"] = surface
+  self.VM.Env["GPULib"] = GPULib
+  self.VM.Env["render"] = render
+  self.VM.Env["WireGPU_matBuffer"] = WireGPU_matBuffer
+
   self.VM.ErrorText = {}
   self.VM.ErrorText[2]  = "Program ended unexpectedly"
   self.VM.ErrorText[3]  = "Arithmetic division by zero"

--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -26,9 +26,18 @@ function ENT:OverrideVM()
     end
   end
 
-  self.VM.Env["surface"] = surface
-  self.VM.Env["GPULib"] = GPULib
-  self.VM.Env["render"] = render
+  self.VM.Env["surface"] = {
+    SetTexture = surface.SetTexture,
+    SetDrawColor = surface.SetDrawColor,
+    DrawRect = surface.DrawRect,
+    DrawTexturedRect = surface.DrawTexturedRect
+  }
+  self.VM.Env["GPULib"] = {
+    Material = GPULib.Material
+  }
+  self.VM.Env["render"] = {
+    CopyTexture = render.CopyTexture
+  }
   self.VM.Env["WireGPU_matBuffer"] = WireGPU_matBuffer
 
   self.VM.ErrorText = {}

--- a/lua/entities/gmod_wire_spu/cl_spuvm.lua
+++ b/lua/entities/gmod_wire_spu/cl_spuvm.lua
@@ -18,6 +18,11 @@ function ENT:OverrideVM()
     end
   end
 
+  self.VM.Env["WireSPU_GetSound"] = WireSPU_GetSound
+  self.VM.Env["WireSPU_SoundCache"] = WireSPU_SoundCache
+  self.VM.Env["WireSPU_MaxChannels"] = WireSPU_MaxChannels
+  self.VM.Env["CreateSound"] = CreateSound
+
   self.VM.Entity = self
 
   self.VM.Interrupt = function(self,interruptNo,interruptParameter,isExternal,cascadeInterrupt)

--- a/lua/wire/zvm/zvm_core.lua
+++ b/lua/wire/zvm/zvm_core.lua
@@ -408,6 +408,7 @@ function ZVM:Precompile_Finalize()
       end
       table.insert(self.IsAddressPrecompiled[address],self.PrecompileStartXEIP)
     end
+    setfenv(result,self.Env)
     self.PrecompiledData[self.PrecompileStartXEIP] = result
   end
 
@@ -661,8 +662,6 @@ function ZVM:Step(overrideSteps,extraEmitFunction)
     end
 
     -- Execute precompiled instruction
-    local previousVM = VM
-    VM = self
     if CLIENT then -- FIXME: hack around crash on PCALL
       self.PrecompiledData[self.XEIP]()
     else
@@ -672,7 +671,6 @@ function ZVM:Step(overrideSteps,extraEmitFunction)
         self:Interrupt(5,1)
       end
     end
-    VM = previousVM
   else
     -- Precompile several next instructions
     self:Precompile_Initialize()
@@ -694,7 +692,9 @@ function ZVM:Step(overrideSteps,extraEmitFunction)
   return
 end
 
-
+-- Any library that's needed by the entirety of the ZVM instruction set should go here
+-- Platform dependant libraries(GPU or SPU for example) should be added to the env by the platform
+ZVM.Env = {["math"]=math, ["string"]=string, ["bit"]=bit, ["VM"]=ZVM}
 
 
 --------------------------------------------------------------------------------

--- a/lua/wire/zvm/zvm_core.lua
+++ b/lua/wire/zvm/zvm_core.lua
@@ -704,7 +704,29 @@ end
 
 -- Any library that's needed by the entirety of the ZVM instruction set should go here
 -- Platform dependant libraries(GPU or SPU for example) should be added to the env by the platform
-ZVM.Env = {["math"]=math, ["string"]=string, ["bit"]=bit, ["VM"]=ZVM}
+ZVM.Env = {
+  math={
+    Clamp = math.Clamp,
+    floor = math.floor,
+    min = math.min,
+    max = math.max,
+    sqrt = math.sqrt,
+    sin = math.sin,
+    cos = math.cos,
+    pi = math.pi,
+    abs = math.abs,
+    random = math.random
+  },
+  bit={
+    bnot = bit.bnot,
+    band = bit.band,
+    bor = bit.bor,
+    bxor = bit.bxor,
+    lshift = bit.lshift,
+    rshift = bit.rshift
+  },
+  VM = ZVM
+}
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Every compiled function from an emitted block is now wrapped in a stripped down environment containing only the necessary libraries, and the VM's contents

Platforms that require extra libraries or outside variables add them to VM.Env to allow the VM to access them