### PR TITLE
ZCPU VM now self-aware like GPU and SPU VMs are

### DIFF
--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -28,6 +28,7 @@ function ENT:Initialize()
 	-- Create virtual machine
 	self.VM = CPULib.VirtualMachine()
 	self.VM.SerialNo = CPULib.GenerateSN("CPU")
+	self.VM.Entity = self
 	-- Since the device supports (quota)interruptible instructions
 	-- Memory access can be a lot cheaper.
 	self.VM.MemoryReadCycles = 2


### PR DESCRIPTION
Stores a reference to the Entity in the VM for the ZCPU

It hadn't occurred to me up until this point that I'm probably going to need this if I want the ZCPU extensions to be able to refer to themselves, like how ZGPU and SPU can.

No baseline functionality is altered, no instructions in the base ZCPU set attempt to access the entity.