### PR TITLE
Copy DIV by zero behavior for handling modulo by zero

### DIFF
--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -409,7 +409,11 @@ ZVM.OpcodeTable[58] = function(self)  --FATAN
   self:Dyn_EmitOperand("math.atan($2)")
 end
 ZVM.OpcodeTable[59] = function(self)  --MOD
-  self:Dyn_EmitOperand("math.fmod($1,$2)")
+  self:Dyn_Emit("$L OP = $2")
+  self:Dyn_EmitOperand("math.fmod($1,OP)")
+  self:Dyn_Emit("if math.abs(OP) < 1e-12 then")
+    self:Dyn_EmitInterrupt("3","0")
+  self:Dyn_Emit("end")
 end
 --------------------------------------------------------------------------------
 ZVM.OpcodeTable[60] = function(self)  --BIT


### PR DESCRIPTION
Div checks if the abs of a number is less than 0.000000000001 (as 1e-12), if this is the case it will send interrupt 3 and not modify the registers value

This PR brings the same behavior to modulo, which was just returning math.fmod(op1,op2), preventing setting a register to NaN and potentially causing errors by outputting it or operating on it.
![gmod_qCeSpRztKf](https://github.com/wiremod/wire-cpu/assets/57756830/941ba00a-dc7b-4991-91fb-5d45e27f9961)
