### PR TITLE
Fix HL-ZASM subtraction

### DIFF
--- a/lua/wire/client/hlzasm/hc_expression.lua
+++ b/lua/wire/client/hlzasm/hc_expression.lua
@@ -505,7 +505,6 @@ function HCOMP:Expression_Level1()
 
   local token = self:PeekToken()
   if (token == self.TOKEN.PLUS) then
-    -- Treat "-" as negate instead of subtraction FIXME (FIXED)
     if token == self.TOKEN.PLUS then self:NextToken() end
 
     local rightLeaf = self:Expression_LevelLeaf(0)

--- a/lua/wire/client/hlzasm/hc_expression.lua
+++ b/lua/wire/client/hlzasm/hc_expression.lua
@@ -504,13 +504,18 @@ function HCOMP:Expression_Level1()
   local leftLeaf = self:Expression_LevelLeaf(2)
 
   local token = self:PeekToken()
-  if (token == self.TOKEN.PLUS) or
-     (token == self.TOKEN.MINUS) then -- +-
-    -- Treat "-" as negate instead of subtraction FIXME
+  if (token == self.TOKEN.PLUS) then
+    -- Treat "-" as negate instead of subtraction FIXME (FIXED)
     if token == self.TOKEN.PLUS then self:NextToken() end
 
     local rightLeaf = self:Expression_LevelLeaf(0)
     return self:NewOpcode("add",leftLeaf,rightLeaf)
+  elseif (token == self.TOKEN.MINUS) then 
+  
+    if token == self.TOKEN.MINUS then self:NextToken() end
+
+    local rightLeaf = self:Expression_LevelLeaf(0)
+    return self:NewOpcode("sub",leftLeaf,rightLeaf)
   elseif (token == self.TOKEN.LAND) or
          (token == self.TOKEN.LOR) then -- &&, ||
     self:NextToken()


### PR DESCRIPTION
Originally when you'd subtract such as var = var - var2
the assembly would output (assuming EAX is var1 and EBX is var2)
NEG EBX
ADD, EAX, EBX
rather than
SUB EAX, EBX