### PR TITLE
Extension Lua Instructions w/ flag can now break precompile

### DIFF
--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -930,6 +930,18 @@ function CPULib:RegisterExtension(name, extension)
           self:Dyn_EmitOperand(2,"interOp[2]")
         self:Dyn_Emit("end")
       ]]
+      local precompileBreakApplied = false
+      for _,i in ipairs(flags) do
+        -- force a break if this is a branching function
+        if (i == "CB" or i == "UB") and not precompileBreakApplied then
+          -- Without this, a CB(conditional branch) or UB(unconditional branch) flagged function will not have VM:Jump take effect.
+          opfunc = opfunc .. [[
+            self:Dyn_EmitBreak()
+            self.PrecompileBreak = true
+          ]]
+          precompileBreakApplied = true
+        end
+      end
     local instruction = self:RegisterInstruction(name, opcount, opfunc, flags, docs)
     instruction.InterOpFunc = luafunc
   end


### PR DESCRIPTION
When instructions in ZVM are branching, they need to set PrecompileBreak on the VM to end the compilation early, this ends the function and when the compiled block is run, any calls to VM:Jump will set VM.IP and be allowed to take effect, since VM.IP won't change as the block runs.

Uses the CB and UB flags to alter this behavior on a per instruction basis at initial load of extension.

So if you flag your function as being Conditionally Branched or Unconditionally Branched when using ext:InstructionFromLuaFunc your function will be able to call VM:Jump and have it take effect properly.