### PR TITLE
Custom RAM/ROM Sizes

### DIFF
--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -142,8 +142,8 @@ local memoryModels = {
 
 function ENT:SetMemoryModel(model,cram,crom)
 	if model == "custom" then
-		self.VM.RAMSize = (tonumber(cram) or 512)*128 -- 65536
-		self.VM.ROMSize = (tonumber(crom) or 512)*128 -- 65536
+		self.VM.RAMSize = math.floor(math.Clamp((tonumber(cram) or 512),0,1024))*128 -- 65536
+		self.VM.ROMSize = math.floor(math.Clamp((tonumber(crom) or 512),0,1024))*128 -- 65536
 		return
 	end
 	self.VM.RAMSize = memoryModels[model][1] or 65536

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -140,7 +140,12 @@ local memoryModels = {
 	["flat"]    = {      0, 0      },
 }
 
-function ENT:SetMemoryModel(model)
+function ENT:SetMemoryModel(model,cram,crom)
+	if model == "custom" then
+		self.VM.RAMSize = (tonumber(cram) or 512)*128 -- 65536
+		self.VM.ROMSize = (tonumber(crom) or 512)*128 -- 65536
+		return
+	end
 	self.VM.RAMSize = memoryModels[model][1] or 65536
 	self.VM.ROMSize = memoryModels[model][2] or 65536
 end

--- a/lua/wire/stools/cpu.lua
+++ b/lua/wire/stools/cpu.lua
@@ -205,6 +205,20 @@ if CLIENT then
       panel:AddControl("Slider", {Label = "RAM size", Command = "wire_cpu_customram", Min = 0, Max = 1024}),
       panel:AddControl("Slider", {Label = "ROM size", Command = "wire_cpu_customrom", Min = 0, Max = 1024}),
     }
+    local function formatPageSizeString(pages)
+      if pages >= 8 then
+        return string.format("KB %g",pages/8) -- padding with spaces won't help because the font isn't monospaced
+      else
+        return string.format(" B  %g",pages*128)
+      end
+    end
+    customMemPanel[2].OnValueChanged = function(self,pages)
+      self:SetText("RAM size "..formatPageSizeString(pages))
+    end
+    customMemPanel[3].OnValueChanged = function(self,pages)
+      self:SetText("ROM size "..formatPageSizeString(pages))
+    end
+
     local memoryModel = GetConVar("wire_cpu_memorymodel")
     function memPanel:OnSelect(index, value, data)
       if data.wire_cpu_memorymodel == "custom" then

--- a/lua/wire/stools/cpu.lua
+++ b/lua/wire/stools/cpu.lua
@@ -218,8 +218,11 @@ if CLIENT then
       end
       -- Overriding this turns off the automatic convar write, so we have to do it ourselves.
         memoryModel:SetString(data.wire_cpu_memorymodel)
+      -- Rebuild the layout to prevent an unsightly gap
+        panel:InvalidateLayout()
+        panel:InvalidateChildren(true)
     end
-
+    memPanel:OnSelect(0,0,{wire_cpu_memorymodel = memoryModel:GetString()}) -- Simulate one on-select to correct the show/hide status
     local enabledExtensionOrder = {}
     local enabledExtensionLookup = {}
     local extensionConvar = GetConVar("wire_cpu_extensions")

--- a/lua/wire/stools/cpu.lua
+++ b/lua/wire/stools/cpu.lua
@@ -19,7 +19,9 @@ TOOL.ClientConVar = {
   model             = "models/cheeze/wires/cpu.mdl",
   filename          = "",
   memorymodel       = "64krom",
-  extensions        = ""
+  extensions        = "",
+  customram         = 0,
+  customrom         = 0
 }
 
 if CLIENT then
@@ -46,7 +48,7 @@ if SERVER then
     if player:KeyDown(IN_SPEED) then
       if (trace.Entity:IsValid()) and
          (trace.Entity:GetClass() == "gmod_wire_cpu") then
-        trace.Entity:SetMemoryModel(self:GetClientInfo("memorymodel"))
+        trace.Entity:SetMemoryModel(self:GetClientInfo("memorymodel"),self:GetClientInfo("customram"),self:GetClientInfo("customrom"))
         trace.Entity:FlashData({})
         net.Start("CPULib.InvalidateDebugger") net.WriteUInt(0,2) net.Send(player)
       end
@@ -76,7 +78,7 @@ if SERVER then
   end
   function TOOL:MakeEnt(ply, model, Ang, trace)
     local ent = WireLib.MakeWireEnt(ply, {Class = self.WireClass, Pos=trace.HitPos, Angle=Ang, Model=model})
-    ent:SetMemoryModel(self:GetClientInfo("memorymodel"))
+    ent:SetMemoryModel(self:GetClientInfo("memorymodel"),self:GetClientInfo("customram"),self:GetClientInfo("customrom"))
     ent:SetExtensionLoadOrder(self:GetClientInfo("extensions"))
     self:LeftClick_Update(trace)
     return ent
@@ -181,7 +183,7 @@ if CLIENT then
 
 
     ----------------------------------------------------------------------------
-    panel:AddControl("ComboBox", {
+    local memPanel = panel:AddControl("ComboBox", {
       Label = "Memory model",
       Options = {
         ["128 bytes ROM only"]  = {wire_cpu_memorymodel = "128rom"},
@@ -194,9 +196,29 @@ if CLIENT then
         ["8KB RAM only"]        = {wire_cpu_memorymodel = "8k"},
         ["128KB RAM/ROM"]       = {wire_cpu_memorymodel = "128krom"},
         ["No internal RAM/ROM"] = {wire_cpu_memorymodel = "flat"},
+        ["Custom RAM/ROM"]      = {wire_cpu_memorymodel = "custom"},
       }
     })
     panel:AddControl("Label", {Text = "Sets the processor memory model (determines interaction with the external devices)"})
+    local customMemPanel = {
+      panel:AddControl("Label", {Text = "Custom memory size for RAM and ROM is in pages(128 bytes)"}),
+      panel:AddControl("Slider", {Label = "RAM size", Command = "wire_cpu_customram", Min = 0, Max = 1024}),
+      panel:AddControl("Slider", {Label = "ROM size", Command = "wire_cpu_customrom", Min = 0, Max = 1024}),
+    }
+    local memoryModel = GetConVar("wire_cpu_memorymodel")
+    function memPanel:OnSelect(index, value, data)
+      if data.wire_cpu_memorymodel == "custom" then
+        for _,i in ipairs(customMemPanel) do
+          i:Show()
+        end
+      else
+        for _,i in ipairs(customMemPanel) do
+          i:Hide()
+        end
+      end
+      -- Overriding this turns off the automatic convar write, so we have to do it ourselves.
+        memoryModel:SetString(data.wire_cpu_memorymodel)
+    end
 
     local enabledExtensionOrder = {}
     local enabledExtensionLookup = {}


### PR DESCRIPTION
Adds support to the ZCPU tool for setting an arbitrary(clamped) number of pages for RAM and ROM separately

Technically possible beforehand, as dupe info saved the ram and rom size, not the memory model, so altering it would allow you to have an arbitrary number of bytes for both, this just provides a UI for sanely setting them in a way that respects the paging system.

Capped at 1024 pages(128kb, same as the largest default memory model)

Sliders are shown for ram/rom when the custom ram/rom option is picked and hidden when custom ram/rom
![Custom ram/rom is picked, displaying two new sliders and a label telling the user that the sliders measure in pages, so the number they pick is multiplied by 128 for the ram and rom sliders](https://github.com/user-attachments/assets/725ee6cf-7230-4d42-9a47-66a8c7165b97)

CPU Reporting 3072 bytes of ram (24 pages, same as the slider depicts)
![gmod_vfcqzeP3zN](https://github.com/user-attachments/assets/4d427eec-9de5-44e6-ab86-1ee970aeb69f)

Leaves a small gap when custom ram/rom isn't selected
![Custom ram/rom option is not picked, and there is a gap the exact same size as where the options once were](https://github.com/user-attachments/assets/ccc1db81-2828-4a2c-9724-9c76a4d56b9e)

CPU Reporting 128 bytes of ram(1 page)
![Screenshot of a CPU reporting internal ram size as 128 bytes](https://github.com/user-attachments/assets/812b907d-f830-4515-9e24-71181d788d62)

