### PR TITLE
LOOPB now ends on 0 instead of -1 like other loops

### DIFF
--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -206,7 +206,7 @@ end
 ZVM.OpcodeTable[26] = function(self)  --LOOPB
   self:Dyn_EmitForceRegisterLocal("EBX")
   self:Dyn_Emit("EBX = EBX - 1")
-  self:Dyn_Emit("if VM.EBX ~= 0 then")
+  self:Dyn_Emit("if EBX ~= 0 then")
     self:Dyn_Emit("VM:Jump($1)")
     self:Dyn_EmitState()
     self:Dyn_EmitBreak()


### PR DESCRIPTION
LOOPB was referencing VM.EBX for its ~= 0 condition and not EBX, the local copy that was modified during *this* call, which meant it was the value before the decrement and not after the decrement.

Documentation of LOOPB was worded the same as LOOPA, LOOPC, LOOP, and LOOPD, which makes me further believe LOOPB's behavior was in error.

Also technically boosts performance of LOOPB,, because it's not indexing EBX from VM twice anymore and is now properly using the local version, same as the other LOOP instructions are.