### PR TITLE
CPU Debugging improvements

### DIFF
--- a/lua/wire/client/text_editor/modes/zcpu.lua
+++ b/lua/wire/client/text_editor/modes/zcpu.lua
@@ -315,6 +315,27 @@ function EDITOR:PopulateMenu(menu)
       CPULib.SetDebugBreakpoint( self.chosenfile, caretPos )
     end)
   end
+  menu:AddOption("Display line using IP", function()
+    CPULib.Debugger.PreferredTracker = "IP"
+    CPULib.Debugger.PreferredTrackerFriendlyName = "IP"
+  end)
+  menu:AddOption("Display line using CS:IP", function()
+    CPULib.Debugger.PreferredTracker = "CSIP"
+    CPULib.Debugger.PreferredTrackerFriendlyName = "CS:IP"
+  end)
+  menu:AddOption("Display line using PHYS IP", function()
+    CPULib.Debugger.PreferredTracker = "PHYSIP"
+    CPULib.Debugger.PreferredTrackerFriendlyName = "PHYS IP"
+  end)
+  if CPULib.Debugger.FollowTracker then
+    menu:AddOption("Don't follow the displayed line", function()
+      CPULib.Debugger.FollowTracker = false
+    end)
+  else
+    menu:AddOption("Follow the displayed line", function()
+      CPULib.Debugger.FollowTracker = true
+    end)
+  end
 end
 
 function EDITOR:Paint()

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -85,7 +85,7 @@ if CLIENT or TESTING then
 
   ------------------------------------------------------------------------------
   -- Make sure the file is opened in the tab
-  function CPULib.SelectTab(editor,fileName,dontSetActive)
+  function CPULib.SelectTab(editor,fileName,dontForceChange)
     if not editor then return end
     local editorType = string.lower(editor.EditorType)
     local fullFileName = editorType.."chip\\"..fileName
@@ -94,6 +94,7 @@ if CLIENT or TESTING then
       fullFileName = fileName
     end
 
+    local currentTab = editor:GetActiveTabIndex()
     local sourceTab
     for tab=1,editor:GetNumTabs() do
       if editor:GetEditor(tab).chosenfile == fullFileName then
@@ -104,8 +105,11 @@ if CLIENT or TESTING then
     if not sourceTab then
       editor:LoadFile(fullFileName,true)
       sourceTab = editor:GetActiveTabIndex()
+      if dontForceChange then
+        editor:SetActiveTab(currentTab)
+      end
     else
-      if not dontSetActive then
+      if not dontForceChange then
         editor:SetActiveTab(sourceTab)
       end
     end

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -32,6 +32,9 @@ if CLIENT or TESTING then
   CPULib.Debugger.Labels = {}
   CPULib.Debugger.PositionByPointer = {}
   CPULib.Debugger.PointersByLine = {}
+  CPULib.Debugger.PreferredTracker = "IP"
+  CPULib.Debugger.PreferredTrackerFriendlyName = "IP"
+  CPULib.Debugger.FollowTracker = true
 
   CPULib.Debugger.Breakpoint = {}
 
@@ -82,7 +85,7 @@ if CLIENT or TESTING then
 
   ------------------------------------------------------------------------------
   -- Make sure the file is opened in the tab
-  function CPULib.SelectTab(editor,fileName)
+  function CPULib.SelectTab(editor,fileName,dontSetActive)
     if not editor then return end
     local editorType = string.lower(editor.EditorType)
     local fullFileName = editorType.."chip\\"..fileName
@@ -102,7 +105,9 @@ if CLIENT or TESTING then
       editor:LoadFile(fullFileName,true)
       sourceTab = editor:GetActiveTabIndex()
     else
-      editor:SetActiveTab(sourceTab)
+      if not dontSetActive then
+        editor:SetActiveTab(sourceTab)
+      end
     end
 
     return editor:GetEditor(sourceTab),sourceTab
@@ -290,7 +295,17 @@ if CLIENT or TESTING then
     else
       table.insert(result,"IP = "..(CPULib.Debugger.Variables.IP or "#####"))
     end
-
+    if CPULib.Debugger.Variables.IP == INVALID_BREAKPOINT_IP then
+      table.insert(result,"CS:IP = #####")
+    else
+      table.insert(result,"CS:IP = "..((CPULib.Debugger.Variables.CSIP) or "#####"))
+    end
+    if CPULib.Debugger.Variables.IP == INVALID_BREAKPOINT_IP then
+      table.insert(result,"PHYS IP = #####")
+    else
+      table.insert(result,"PHYS IP = "..(CPULib.Debugger.Variables.PHYSIP or "#####"))
+    end
+    table.insert(result,"Following "..CPULib.Debugger.PreferredTrackerFriendlyName)
     if CPULib.InterruptText then
       table.insert(result,"")
       table.insert(result,CPULib.InterruptText)
@@ -308,7 +323,7 @@ if CLIENT or TESTING then
     CPULib.Debugger.Breakpoint = {}
     CPULib.Debugger.Variables = {}
     CPULib.Debugger.FirstFile = nil
-    CPULib.DebugUpdateHighlights()
+    CPULib.DebugUpdateHighlights(not CPULib.Debugger.FollowTracker)
   end
 
   net.Receive("CPULib.InvalidateDebugger", function(netlen)
@@ -352,15 +367,15 @@ if CLIENT or TESTING then
   function CPULib.DebugUpdateHighlights(dontForcePosition)
     if ZCPU_Editor then
       -- Highlight current position
-      local currentPosition = CPULib.Debugger.PositionByPointer[CPULib.Debugger.Variables.IP]
+      local currentPosition = CPULib.Debugger.PositionByPointer[CPULib.Debugger.Variables[CPULib.Debugger.PreferredTracker or "IP"]]
 
       if currentPosition then
         -- Clear all highlighted lines
         for tab=1,ZCPU_Editor:GetNumTabs() do
           ZCPU_Editor:GetEditor(tab):ClearHighlightedLines()
         end
-
-        local textEditor = CPULib.SelectTab(ZCPU_Editor,currentPosition.File)
+        
+        local textEditor = CPULib.SelectTab(ZCPU_Editor,currentPosition.File,not CPULib.Debugger.FollowTracker)
         if textEditor then
           textEditor:HighlightLine(currentPosition.Line,130,0,0,255)
           if not dontForcePosition then
@@ -397,21 +412,24 @@ if CLIENT or TESTING then
   ------------------------------------------------------------------------------
   -- Debug data arrived from server
   function CPULib.OnDebugData_Registers(um)
-    CPULib.Debugger.Variables.IP   = um:ReadFloat()
-    CPULib.Debugger.Variables.EAX  = um:ReadFloat()
-    CPULib.Debugger.Variables.EBX  = um:ReadFloat()
-    CPULib.Debugger.Variables.ECX  = um:ReadFloat()
-    CPULib.Debugger.Variables.EDX  = um:ReadFloat()
-    CPULib.Debugger.Variables.ESI  = um:ReadFloat()
-    CPULib.Debugger.Variables.EDI  = um:ReadFloat()
-    CPULib.Debugger.Variables.EBP  = um:ReadFloat()
-    CPULib.Debugger.Variables.ESP  = um:ReadFloat()
-
+    CPULib.Debugger.Variables.CS       = um:ReadFloat()
+    CPULib.Debugger.Variables.IP       = um:ReadFloat()
+    CPULib.Debugger.Variables.PHYSPAGE = um:ReadFloat()
+    CPULib.Debugger.Variables.EAX      = um:ReadFloat()
+    CPULib.Debugger.Variables.EBX      = um:ReadFloat()
+    CPULib.Debugger.Variables.ECX      = um:ReadFloat()
+    CPULib.Debugger.Variables.EDX      = um:ReadFloat()
+    CPULib.Debugger.Variables.ESI      = um:ReadFloat()
+    CPULib.Debugger.Variables.EDI      = um:ReadFloat()
+    CPULib.Debugger.Variables.EBP      = um:ReadFloat()
+    CPULib.Debugger.Variables.ESP      = um:ReadFloat()
+    CPULib.Debugger.Variables.CSIP     = CPULib.Debugger.Variables.CS + CPULib.Debugger.Variables.IP
+    CPULib.Debugger.Variables.PHYSIP   = CPULib.Debugger.Variables.PHYSPAGE*128 + CPULib.Debugger.Variables.CSIP%128
     for reg=0,31 do
       CPULib.Debugger.Variables["R"..reg]  = um:ReadFloat()
     end
 
-    CPULib.DebugUpdateHighlights()
+    CPULib.DebugUpdateHighlights(not CPULib.Debugger.FollowTracker)
   end
   usermessage.Hook("cpulib_debugdata_registers", CPULib.OnDebugData_Registers)
 
@@ -613,7 +631,13 @@ if SERVER then
 
     if not onlyMemPointers then
       umsg.Start("cpulib_debugdata_registers", umsgrp)
+        umsg.Float(VM.CS)
         umsg.Float(VM.IP)
+        if(VM.CurrentPage.Remapped == 1) then
+          umsg.Float(VM.CurrentPage.MappedIndex)
+        else
+          umsg.Float(math.floor((VM.CS+VM.IP)/128))
+        end
         umsg.Float(VM.EAX)
         umsg.Float(VM.EBX)
         umsg.Float(VM.ECX)


### PR DESCRIPTION
CPU debugging now networks CS, and the current physical page the CPU is executing from.

Now displays CS:IP and PHYS IP (physical page * 128 )+(CS:IP % 128)
You can now choose to follow IP, CS:IP, or Phys IP in your files from the right click menu, and also turn off automatically scrolling and switching files if you want to scroll on your own.
![image](https://github.com/user-attachments/assets/778921e6-fbb9-4c22-aa99-6d1a6d6c8da8)
