### PR TITLE
E2Helper & Text Editor Module Support

### DIFF
--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -670,7 +670,7 @@ function HCOMP:SetSpecialLabels()
   self:SetLabel("__DATE_MINUTE__",tonumber(os.date("%M")))
   self:SetLabel("__DATE_SECOND__",tonumber(os.date("%S")))
 
-  if self.Settings.CurrentPlatform == "GPU" then
+  if string.match(self.Settings.CurrentPlatform, "GPU$") then
     self:SetLabel("regClk",           65535)
     self:SetLabel("regReset",         65534)
     self:SetLabel("regHWClear",       65533)

--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -9,12 +9,12 @@
 --------------------------------------------------------------------------------
 -- Load file
 function HCOMP:LoadFile(filename)
-  return file.Read("data/"..self.Settings.CurrentPlatform.."Chip/"..filename, "GAME") -- So we also get /addons/wire/data/
+  return file.Read("data/"..self.Location.."/"..filename, "GAME") -- So we also get /addons/wire/data/
 end
 
 -- Save file
 function HCOMP:SaveFile(filename,text)
-  file.Write(self.Settings.CurrentPlatform.."Chip/"..filename,text)
+  file.Write(self.Location.."/"..filename,text)
 end
 
 -- Trim spaces at string sides

--- a/lua/wire/client/text_editor/modes/zcpu.lua
+++ b/lua/wire/client/text_editor/modes/zcpu.lua
@@ -3,7 +3,11 @@ local string_gmatch = string.gmatch
 local string_gsub = string.gsub
 local draw_WordBox = draw.WordBox
 
-local EDITOR = {}
+local EDITOR = {
+  UseValidator = true,
+  Validator = CPULib.Validate,
+  E2HelperCategory = "ZASM", -- As an override, makes GPU and SPU use the ZCPU helper too
+}
 
 -- CPU hint box
 local oldpos, haschecked = {0,0}, false
@@ -151,7 +155,11 @@ end
 
 function EDITOR:ShowContextHelp(word)
   E2Helper.Show()
-  E2Helper.UseCPU(self:GetParent().EditorType)
+  if E2Helper.Modes then
+    E2Helper:SetMode("ZASM")
+  else
+    E2Helper.UseCPU(self:GetParent().EditorType)
+  end
   E2Helper.Show(word)
 end
 
@@ -362,3 +370,16 @@ function EDITOR:Paint()
 end
 
 WireTextEditor.Modes.ZCPU = EDITOR
+WireTextEditor.Modes.ZGPU = EDITOR
+local ZSPU = {
+  UseSoundBrowser = true
+}
+
+-- Proxy everything else from the ZCPU editor.
+local ZSPU_Meta = {
+  __index = function(self,key) return EDITOR[key] end
+}
+
+setmetatable(ZSPU,ZSPU_Meta)
+
+WireTextEditor.Modes.ZSPU = ZSPU

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -893,7 +893,7 @@ if CLIENT then
       end
     end
     table.insert(CPULib.CreateInstructionHooks,helperCreateInstructionHook)
-    table.insert(CPULib.DestroyInstructionHooks,helperDestroyInstructionHook)
+    table.insert(CPULib.RemoveInstructionHooks,helperDestroyInstructionHook)
     end
   end)
 end

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -88,10 +88,11 @@ if CLIENT or TESTING then
   function CPULib.SelectTab(editor,fileName,dontForceChange)
     if not editor then return end
     local editorType = string.lower(editor.EditorType)
-    local fullFileName = editorType.."chip\\"..fileName
-
-    if string.sub(fileName,1,7) == editorType.."chip" then
+    local fullFileName
+    if string.match(fileName,"^"..editor.Location) then
       fullFileName = fileName
+    else
+      fullFileName = editor.Location.."/"..fileName
     end
 
     local currentTab = editor:GetActiveTabIndex()

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -45,7 +45,7 @@ if CLIENT or TESTING then
 
   ------------------------------------------------------------------------------
   -- Request compiling specific sourcecode
-  function CPULib.Compile(source,fileName,successCallback,errorCallback,targetPlatform)
+  function CPULib.Compile(source,fileName,successCallback,errorCallback,targetPlatform,sourceDirectory)
     -- Stop any compile/upload process that is running right now
     timer.Remove("cpulib_compile")
     timer.Remove("cpulib_upload")
@@ -72,6 +72,7 @@ if CLIENT or TESTING then
 
     -- Start compiling the sourcecode
     HCOMP.Settings.CurrentPlatform = targetPlatform or "CPU"
+    HCOMP.Location = sourceDirectory or HCOMP.Settings.CurrentPlatform .. "chip"
     print("=== HL-ZASM High Level Assembly Compiler Output ==")
 
     -- Initialize callbacks
@@ -144,7 +145,7 @@ if CLIENT or TESTING then
         end
 
         editor.C.Val:Update({{message = issue, line = line, char = char}}, nil, issue, Color(128, 20, 50))
-      end,editor.EditorType)
+      end,editor.EditorType,editor.Location)
   end
 
   ------------------------------------------------------------------------------

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -374,8 +374,12 @@ if CLIENT or TESTING then
     if ZCPU_Editor then
       -- Highlight current position
       local currentPosition = CPULib.Debugger.PositionByPointer[CPULib.Debugger.Variables[CPULib.Debugger.PreferredTracker or "IP"]]
-
       if currentPosition then
+        -- Check if currentposition is even in the correct editor first, when switching editors CPULib's debugging info switches
+        -- to the file in the new editor.
+        if not currentPosition.File:sub(1,9):match("cpuchip/") then
+          return
+        end
         -- Clear all highlighted lines
         for tab=1,ZCPU_Editor:GetNumTabs() do
           ZCPU_Editor:GetEditor(tab):ClearHighlightedLines()

--- a/lua/wire/stools/cpu.lua
+++ b/lua/wire/stools/cpu.lua
@@ -123,7 +123,7 @@ if CLIENT then
   function ZCPU_OpenEditor()
     if not ZCPU_Editor then
       ZCPU_Editor = vgui.Create("Expression2EditorFrame")
-      ZCPU_Editor:Setup("ZCPU Editor", "cpuchip", "CPU")
+      CPULib.SetupEditor(ZCPU_Editor,"ZCPU Editor", "cpuchip", "CPU")
     end
     ZCPU_Editor:Open()
   end
@@ -148,7 +148,7 @@ if CLIENT then
     function FileBrowser:OnFileOpen(filepath, newtab)
       if not ZCPU_Editor then
         ZCPU_Editor = vgui.Create("Expression2EditorFrame")
-        ZCPU_Editor:Setup("ZCPU Editor", "cpuchip", "CPU")
+        CPULib.SetupEditor(ZCPU_Editor,"ZCPU Editor", "cpuchip", "CPU")
       end
       ZCPU_Editor:Open(filepath, nil, newtab)
     end

--- a/lua/wire/stools/cpu.lua
+++ b/lua/wire/stools/cpu.lua
@@ -112,7 +112,7 @@ if CLIENT then
   ------------------------------------------------------------------------------
   function ZCPU_RequestCode()
     if ZCPU_Editor then
-      CPULib.Compile(ZCPU_Editor:GetCode(),ZCPU_Editor:GetChosenFile(),compile_success,compile_error)
+      CPULib.Compile(ZCPU_Editor:GetCode(),ZCPU_Editor:GetChosenFile(),compile_success,compile_error,"CPU",ZCPU_Editor.Location)
     end
   end
   net.Receive("ZCPU_RequestCode", ZCPU_RequestCode)

--- a/lua/wire/stools/gpu.lua
+++ b/lua/wire/stools/gpu.lua
@@ -102,7 +102,7 @@ if CLIENT then
   function ZGPU_OpenEditor()
     if not ZGPU_Editor then
       ZGPU_Editor = vgui.Create("Expression2EditorFrame")
-      ZGPU_Editor:Setup("ZGPU Editor", "gpuchip", "GPU")
+      CPULib.SetupEditor(ZGPU_Editor,"ZGPU Editor", "gpuchip", "GPU")
     end
     ZGPU_Editor:Open()
   end
@@ -127,7 +127,7 @@ if CLIENT then
     function FileBrowser:OnFileOpen(filepath, newtab)
       if not ZGPU_Editor then
         ZGPU_Editor = vgui.Create("Expression2EditorFrame")
-        ZGPU_Editor:Setup("ZGPU Editor", "gpuchip", "GPU")
+        CPULib.SetupEditor(ZGPU_Editor,"ZGPU Editor", "gpuchip", "GPU")
       end
       ZGPU_Editor:Open(filepath, nil, newtab)
     end

--- a/lua/wire/stools/gpu.lua
+++ b/lua/wire/stools/gpu.lua
@@ -91,7 +91,7 @@ if CLIENT then
   function ZGPU_RequestCode()
     if ZGPU_Editor then
       CPULib.Debugger.SourceTab = ZGPU_Editor:GetActiveTab()
-      CPULib.Compile(ZGPU_Editor:GetCode(),ZGPU_Editor:GetChosenFile(),compile_success,compile_error,"GPU")
+      CPULib.Compile(ZGPU_Editor:GetCode(),ZGPU_Editor:GetChosenFile(),compile_success,compile_error,"GPU",ZGPU_Editor.Location)
     end
   end
   net.Receive("ZGPU_RequestCode", ZGPU_RequestCode)

--- a/lua/wire/stools/spu.lua
+++ b/lua/wire/stools/spu.lua
@@ -100,7 +100,7 @@ if CLIENT then
   function ZSPU_OpenEditor()
     if not ZSPU_Editor then
       ZSPU_Editor = vgui.Create("Expression2EditorFrame")
-      ZSPU_Editor:Setup("ZSPU Editor", "spuchip", "SPU")
+      CPULib.SetupEditor(ZSPU_Editor,"ZSPU Editor", "spuchip", "SPU")
     end
     ZSPU_Editor:Open()
   end
@@ -132,7 +132,7 @@ if CLIENT then
 	function FileBrowser:OnFileOpen(filepath, newtab)
 	  if not ZSPU_Editor then
         ZSPU_Editor = vgui.Create("Expression2EditorFrame")
-        ZSPU_Editor:Setup("ZSPU Editor", "spuchip", "SPU")
+        CPULib.SetupEditor(ZSPU_Editor,"ZSPU Editor", "spuchip", "SPU")
       end
       ZSPU_Editor:Open(filepath, nil, newtab)
     end

--- a/lua/wire/stools/spu.lua
+++ b/lua/wire/stools/spu.lua
@@ -89,7 +89,7 @@ if CLIENT then
   function ZSPU_RequestCode()
     if ZSPU_Editor then
       CPULib.Debugger.SourceTab = ZSPU_Editor:GetActiveTab()
-      CPULib.Compile(ZSPU_Editor:GetCode(),ZSPU_Editor:GetChosenFile(),compile_success,compile_error)
+      CPULib.Compile(ZSPU_Editor:GetCode(),ZSPU_Editor:GetChosenFile(),compile_success,compile_error,"SPU",ZSPU_Editor.Location)
     end
   end
   net.Receive("ZSPU_RequestCode", ZSPU_RequestCode)


### PR DESCRIPTION
Provides support for the upcoming changes in https://github.com/wiremod/wire/pull/3127 by porting some of the functionality of the original E2Helper implementation for ZCPU here.


The changes allow loaded extensions to display their instructions properly in E2Helper thanks to being able to update descriptions and items at CPULib's will.
![gmod_LkmYi0Urzr](https://github.com/user-attachments/assets/1205df88-fff4-4215-a842-f51fdf4d5988)

Backwards compatible with older versions of wiremod before this change, letting the hardcoded E2Helper & Text Editor control us, but the new version of wiremod won't be able to support versions of ZCPU before this, sadly.

(this is what it'll look like for an older zcpu version on new wiremod, still compiles when you click but no syntax highlighting or helper, technically functional)
![image](https://github.com/user-attachments/assets/237e26ca-74c6-4663-9eb3-408a31480fa4)