### PR TITLE
Stop marking R0-R31 as needing interrupt checks

### DIFF
--- a/lua/wire/zvm/zvm_data.lua
+++ b/lua/wire/zvm/zvm_data.lua
@@ -444,8 +444,10 @@ ZVM.NeedInterruptCheck[38] = true
 ZVM.NeedInterruptCheck[39] = true
 ZVM.NeedInterruptCheck[40] = true
 ZVM.NeedInterruptCheck[41] = true
+-- Ports section
 for i=1000,2023 do ZVM.NeedInterruptCheck[i] = true end
-for i=2048,2207 do ZVM.NeedInterruptCheck[i] = true end
+-- Starts just after R31, so these ones past that are going to be the memory access modifiers.
+for i=2048+32,2207 do ZVM.NeedInterruptCheck[i] = true end
 
 -- Register lookup table   FIXME: add segments
 ZVM.NeedRegisterLookup = {}


### PR DESCRIPTION
For R0-R31 being used as a register, previously it would do an interrupt check as if it were a memory access, this will no longer be the case and R0-R31 access (as registers, not using them for memory access) will no longer use interrupt checks, bringing them to an equal performance as using the regular(EAX, EBX, etc.) registers.