### PR TITLE
Privileged instructions can now be proxied by interrupt 13

### DIFF
--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -292,6 +292,12 @@ function VM:Reset()
   self.INTR = 0       -- Handling an interrupt
   self.BlockStart = 0 -- Start of the block
   self.BlockSize = 0  -- Size of the block
+  self.QUOTIMER = 0
+  self.QUOCMP = 0
+  self.PreqOperand1 = 0
+  self.PreqOperand2 = 0
+  self.PreqHandled = 0
+  self.PreqReturn = 0
 
   -- Reset internal GPU registers
   --  [131072]..[2097151] - Extended GPU memory (2MB GPU)

--- a/lua/entities/gmod_wire_spu/cl_spuvm.lua
+++ b/lua/entities/gmod_wire_spu/cl_spuvm.lua
@@ -137,6 +137,12 @@ function VM:Reset()
   self.INTR = 0       -- Handling an interrupt
   self.BlockStart = 0 -- Start of the block
   self.BlockSize = 0  -- Size of the block
+  self.QUOTIMER = 0
+  self.QUOCMP = 0
+  self.PreqOperand1 = 0
+  self.PreqOperand2 = 0
+  self.PreqHandled = 0
+  self.PreqReturn = 0
 
   self.EntryPoint0 = 0
   self.EntryPoint1 = 0

--- a/lua/wire/zvm/zvm_core.lua
+++ b/lua/wire/zvm/zvm_core.lua
@@ -542,7 +542,7 @@ function ZVM:Precompile_Step()
   if self.OpcodeRunLevel[Opcode] then
     self:Dyn_BeginUnprivilegedCode(self.OpcodeRunLevel[Opcode])
       self:Dyn_Emit("if VM.PreqHandled == 0 then")
-        self:Dyn_EmitInterrupt(13,Opcode)
+        self:Dyn_EmitUnprivilegedRequestInterrupt(Opcode)
       self:Dyn_Emit("end")
       -- Skip running the privileged code if this was deemed "handled"
       self:Dyn_Emit("VM.PreqHandled = 0")

--- a/lua/wire/zvm/zvm_core.lua
+++ b/lua/wire/zvm/zvm_core.lua
@@ -380,6 +380,31 @@ function ZVM:Dyn_EndQuotaInterrupt()
   self:Dyn_Emit("end")
 end
 
+-- Allows you to set up code that runs if greater than this runlevel
+function ZVM:Dyn_BeginUnprivilegedCode(Runlevel)
+  self:Emit("if (VM.PCAP == 1) and (VM.CurrentPage.RunLevel > %d) then",Runlevel)
+end
+
+-- For readability to signify the end of an unprivileged block.
+function ZVM:Dyn_EndUnprivilegedCode()
+  self:Emit("end")
+end
+
+-- Set PreqOperands and an interrupt to return to just before this instruction, so it can be handled like a MEMRQ
+function ZVM:Dyn_EmitUnprivilegedRequestInterrupt(Opcode)
+  self:Dyn_Emit("VM.PreqOperand1 = $1 or 0")
+  self:Dyn_Emit("VM.PreqOperand2 = $2 or 0")
+  self:Dyn_Emit("VM.PreqReturn = 0")
+  -- Default PreqHandled to -1 (meaning unhandled, don't take return value, just skip the instruction)
+  self:Dyn_Emit("VM.PreqHandled = -1")
+  -- Return to just before instruction, to allow the instruction to get the return value if handled
+  self:Dyn_EmitState()
+  self:Dyn_Emit("VM.IP = %d",self.PrecompileIP-self.PrecompileCurInstructionSize)
+  self:Dyn_Emit("VM.XEIP = %d",self.PrecompileXEIP-self.PrecompileCurInstructionSize)
+  self:Dyn_Emit("VM:Interrupt(13,%d)",Opcode)
+  self:Dyn_EmitBreak()
+end
+
 --------------------------------------------------------------------------------
 function ZVM:Precompile_Initialize()
   self.PrecompileXEIP = self.XEIP
@@ -515,9 +540,14 @@ function ZVM:Precompile_Step()
 
   -- Check opcode runlevel
   if self.OpcodeRunLevel[Opcode] then
-    self:Emit("if (VM.PCAP == 1) and (VM.CurrentPage.RunLevel > %d) then",self.OpcodeRunLevel[Opcode])
-      self:Dyn_EmitInterrupt("13",Opcode)
-    self:Emit("end")
+    self:Dyn_BeginUnprivilegedCode(self.OpcodeRunLevel[Opcode])
+      self:Dyn_Emit("if VM.PreqHandled == 0 then")
+        self:Dyn_EmitInterrupt(13,Opcode)
+      self:Dyn_Emit("end")
+      -- Skip running the privileged code if this was deemed "handled"
+      self:Dyn_Emit("VM.PreqHandled = 0")
+    self:Dyn_Emit("else")
+      -- Privileged code will get wrapped in this block
   end
 
   -- Calculate operand RM bytes
@@ -631,6 +661,10 @@ function ZVM:Precompile_Step()
     -- Emit interrupt check
     if self.EmitNeedInterruptCheck then
       self:Dyn_EmitInterruptCheck()
+    end
+    if self.OpcodeRunLevel[Opcode] then
+      -- Wrap the privileged block up here.
+      self:Dyn_EndUnprivilegedCode()
     end
   end
 

--- a/lua/wire/zvm/zvm_data.lua
+++ b/lua/wire/zvm/zvm_data.lua
@@ -83,8 +83,13 @@ ZVM.InternalRegister[65] = "TimerRate"
 ZVM.InternalRegister[66] = "TimerPrevTime"
 ZVM.InternalRegister[67] = "TimerAddress"
 ZVM.InternalRegister[68] = "TimerPrevMode"
+----------------------------------
 ZVM.InternalRegister[69] = "LASTQUO"
 ZVM.InternalRegister[70] = "QUOFLAG"
+ZVM.InternalRegister[71] = "PreqOperand1"
+ZVM.InternalRegister[72] = "PreqOperand2"
+ZVM.InternalRegister[73] = "PreqReturn"
+ZVM.InternalRegister[74] = "PreqHandled"
 ----------------------------------
 for reg=0,31 do ZVM.InternalRegister[96+reg] = "R"..reg end
 

--- a/lua/wire/zvm/zvm_features.lua
+++ b/lua/wire/zvm/zvm_features.lua
@@ -111,6 +111,12 @@ function ZVM:Reset()
   self.BlockSize = 0       -- Size of the block
   self.HaltPort = 0        -- Unused/obsolete
   self.TimerDT = 0         -- Timer deltastep within cached instructions block
+  self.QUOTIMER = 0
+  self.QUOCMP = 0
+  self.PreqOperand1 = 0    -- Privileged Request Operands (used in interrupt 13 for opcodes requiring runlevel 0)
+  self.PreqOperand2 = 0 
+  self.PreqHandled = 0
+  self.PreqReturn = 0
 
   -- Runlevel registers
   self.CRL  = 0            -- Current runlevel


### PR DESCRIPTION
Now upon executing a privileged instruction without being of the right runlevel, the interrupt will pass the privileged instruction's operands into PreqOperand1 and PreqOperand2, and certain instructions that needed to write to an operand can now retrieve a return value from PreqReturn.

Internal registers added:
71 = PreqOperand1 | in MOV R0,R1, this would hold R0
72 = PreqOperand2 | in MOV R0,R1, this would hold R1
73 = PreqReturn | The number to be returned, if the instruction needs one.
74 = PreqHandled | Whether or not this request was handled, is set to -1 on entering interrupt, if set to 1 then PreqReturn will be used if needed. As long as it's nonzero the privileged instruction is considered handled on return

Opcodes that will use PreqReturn:
CPUGET
RD
GMAP (which I've also fixed in this PR)

Example use cases:

Overriding program's use of CPUGET, you could make a program that gets register 43(size of cpu internal memory) instead receive the size of the program's allotted memory(making it work without needing to recompile it to use a constant mem size)

Running previously privileged code without having to put it on runlevel 0, by handling specific instructions and ignoring others rather than flat out denying all.

Example code:
(This divides the CPU's memory by 2 before returning it)
![image](https://github.com/user-attachments/assets/e51961a5-aad2-41ff-aadc-0a8c668b97d1)