### PR TITLE
Use MEMRQ = 6 to signify interrupt handled write

### DIFF
--- a/lua/wire/zvm/zvm_features.lua
+++ b/lua/wire/zvm/zvm_features.lua
@@ -312,9 +312,14 @@ function ZVM:WriteCell(Address,Value)
     --        2 - read interrupt requested
     --        3 - write interrupt requested
     --        4 - read interrupt handled
-    --        5 - write interrupt handled
+    --        5 - write address / value changed, write request is allowed
+    --        6 - write request handled by interrupt, skip performing the write ourselves
     -- Check if page is overriden
     if Page.Override == 1 then
+      if self.MEMRQ == 6 then -- Skip performing the write ourselves, the interrupt did it for us.
+        self.MEMRQ = 0
+        return true
+      end
       if self.MEMRQ == 5 then -- write IRQ handled, new address/value available
         self.MEMRQ = 0
         Address = self.MEMADDR


### PR DESCRIPTION
MEMRQ = 5 just takes Address and Value from MEMADDR and LADD, before performing the write itself.

If the user wanted to cancel a write request or perform another operation on write instead, they would still end up having the operation perform, and a byte written to the trapped page by default(the write is non-negotiable, it HAS to go somewhere, and preventing a value changing from write requires hacky workarounds).

MEMRQ = 6, which is new, will outright cancel a write request instead of just changing the address and value, allowing you to prevent any write happening at all without having to do a workaround.