### PR TITLE
DARRAY Instruction implemented

### DIFF
--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -1316,7 +1316,7 @@ GPU(232, "DSCRSIZE",      2,    0.5,    0,         "X",     "Y",     "Set screen
 GPU(233, "DROTATESCALE",  2,    0.5,    0,         "X",     "Y",     "Rotate by X, scale by Y")
 GPU(234, "DORECTWH",      2,    0.5,    0,         "VEC2F", "VEC2F", "Draw an outlined rectangle by width/height")
 GPU(235, "DCULLMODE",     2,    0.7,    0,         "IDX",   "IDX",   "Set cullmode and lighting mode")
---GPU(236, "DARRAY",        2,    1.0,    0,         "VEC2F", "STRUCT","Draw an array of pixels")
+GPU(236, "DARRAY",        2,    1.0,    0,         "VEC2F", "STRUCT","Draw an array of width/height rectangles.\nStruct layout:\nResolution X, Resolution Y, Pixel Width, Pixel Height, Color Mode(like digital screen), Pointer to color buffer")
 --GPU(237, "DDTERMINAL",    2,    1.0,    0,         "VEC2F", "STRUCT","Draw a console screen/terminal window")
 GPU(238, "DPIXEL",        2,    1.0,    0,         "VEC2F", "COLOR", "Draw a pixel to screen")
 GPU(239, "RESERVED",      2,    0.0,    0,         "",      "",      "")


### PR DESCRIPTION
Implements the DARRAY instruction

Though the only documentation of its existence was a commented out CPULIB entry stating that it took VEC2F, and STRUCT as arguments, and the description stating "Draw an array of pixels", this adds it in a functional state.

VEC2F is position to start draw
STRUCT is a pointer to a struct made up of:
Resolution X
Resolution Y
Pixel Width
Pixel Height
Color Mode (this currently has the same set of color modes as the digital screen)
Pointer to color buffer

Uses a quota interrupt like MCOPY to allow a buffer of any size to be drawn.

Color modes available:
0 = RGBXXX (1 cell per pixel)
1 = R G B (3 cells per pixel)
2 = 24 Bit RGB / True Color Mode (1 cell per pixel)
3 = RRRGGGBBB / Digit packed RGB mode (1 cell per pixel)
4 = Mono color / Grayscale (1 cell per pixel)

Color modes 0, 2, and 3 all cache colors and add an arbitrarily defined cycle penalty for each uncached color that needs processing.
Cycle penalty for mode 0 = 8 cycles
Cycle penalty for mode 2 = 10 cycles
Cycle penalty for mode 3 = 15 cycles

All examples below are running on a GPU in a 2.1MHz async thread, and are using color mode 2

Example showing its rendering speed for a 512x512 pattern of 8 colors

https://github.com/user-attachments/assets/3927fd28-c0a1-4899-bd47-0a9020cc6099

Example showing its rendering speed for a 512x512 pattern of unique colors(262144 colors total, getting full caching penalty for each pixel)

https://github.com/user-attachments/assets/c0791b8f-858c-45e7-9037-38d3798c7318

Example showing it rendering an 128x128 image of the workshop image for wire-cpu, scaled up to 512x512 by setting Pixel Width and Pixel Height to 4,4 in the DARRAY struct

https://github.com/user-attachments/assets/33694bf2-42e1-4b71-9a9c-62f2c15be1ff