### PR TITLE
Add syntax highlighting to structs to be like other types.

### DIFF
--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -196,6 +196,16 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
   self.WriteByteCallback = writeByteCallback
   self.WriteByteCaller = writeByteCaller
 
+  -- Refresh the keywords table.
+  local keywordsTable =  WireTextEditor.Modes.ZCPU.keywordsTable
+  local keywordsTableOriginal = WireTextEditor.Modes.ZCPU.keywordsTableOriginal
+
+  for k,v in pairs(keywordsTable) do
+      if keywordsTableOriginal[k] == nil then
+          keywordsTable[k] = nil
+      end
+  end
+
   -- Set the working directory
   self.FileName = string.sub(fileName,string.find(fileName,"\\$") or 1)
   if string.GetPathFromFilename then

--- a/lua/wire/client/hlzasm/hc_syntax.lua
+++ b/lua/wire/client/hlzasm/hc_syntax.lua
@@ -461,6 +461,7 @@ function HCOMP:DefineVariable(isFunctionParam,isForwardDecl,isRegisterDecl,isStr
     varType = self.TokenData
     varSize = 0 -- Depends on pointer level
     isStruct = true
+    WireTextEditor.Modes.ZCPU.keywordsTable[string.upper(varType)] = true -- Add the new struct to the keywords table.
   else -- Define variable
     self:ExpectToken(TOKEN.TYPE)
     varType = self.TokenData

--- a/lua/wire/client/text_editor/modes/zcpu.lua
+++ b/lua/wire/client/text_editor/modes/zcpu.lua
@@ -91,10 +91,15 @@ local keywordsList = {
   "INT","FLOAT","CHAR","VOID","PRESERVE","ZAP","STRUCT","VECTOR"
 }
 
-local keywordsTable = {}
+EDITOR.keywordsTable = {}
+local keywordsTable = EDITOR.keywordsTable
+
 for k,v in pairs(keywordsList) do
   keywordsTable[v] = true
 end
+
+-- For checking the keywords to remove structs in the editor.
+EDITOR.keywordsTableOriginal = table.Copy(keywordsTable)
 
 -- Build lookup table for registers
 local registersTable = {
@@ -194,13 +199,16 @@ function EDITOR:SyntaxColorLine(row)
     if self:NextPattern(".-%*/") then
       self.blockcomment = nil
     else
-      self:NextPattern(".*")
+      self:NextPattern(".*") 
     end
 
     cols[#cols + 1] = {self.tokendata, colors["comment"]}
   end
 
   local isGpu = self:GetParent().EditorType == "GPU"
+
+  -- Remember the last token to prevent structs from being highlighted.
+  local previousToken = ""
 
   while self.character do
     local tokenname = ""
@@ -217,13 +225,15 @@ function EDITOR:SyntaxColorLine(row)
         tokenname = "opcode"
       elseif registersTable[sstr] then
         tokenname = "register"
-      elseif keywordsTable[sstr] then
+      elseif keywordsTable[sstr] and (previousToken ~= "STRUCT") then -- Default to number/normal if it's declaring a struct.
         tokenname = "keyword"
       elseif tonumber(self.tokendata) then
         tokenname = "number"
       else
         tokenname = "normal"
       end
+
+      previousToken = sstr
     elseif (self.character == "'") or (self.character == "\"")  then
       tokenname = "string"
       local delimiter = self.character

--- a/lua/wire/client/text_editor/modes/zcpu.lua
+++ b/lua/wire/client/text_editor/modes/zcpu.lua
@@ -199,7 +199,7 @@ function EDITOR:SyntaxColorLine(row)
     if self:NextPattern(".-%*/") then
       self.blockcomment = nil
     else
-      self:NextPattern(".*") 
+      self:NextPattern(".*")
     end
 
     cols[#cols + 1] = {self.tokendata, colors["comment"]}


### PR DESCRIPTION
Makes the code editor more unified and better to look at rather than some types being colored and your structs being the same color as regular text.

The keywords are added during compile and will change once you type. When you compile a script that does not have those structs they will be removed from the list to highlight.

## Before
![image](https://github.com/user-attachments/assets/753480d1-0c67-4527-998c-a8dc187053ef)

## After
![image](https://github.com/user-attachments/assets/1ab510d2-a2d5-4582-ac9c-ee7dc1242c37)

