### PR TITLE
Fix LEA instruction

### DIFF
--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -1156,7 +1156,7 @@ end
 ZVM.OpcodeTable[126] = function(self)  --LEA
   local emitText = self.OperandEffectiveAddress[self.EmitOperandRM[2]] or "0"
   emitText = string.gsub(emitText,"$BYTE",self.EmitOperandByte[2] or "0")
-  emitText = string.format(string.gsub(emitText,"$SEG","VM[%q]",(self.EmitOperandSegment[2] or "DS")))
+  emitText = string.format(string.gsub(emitText,"$SEG","VM[%q]"), self.EmitOperandSegment[2] or "DS")
   self:Dyn_EmitOperand(emitText)
 end
 ZVM.OpcodeTable[127] = function(self)  --BLOCK


### PR DESCRIPTION
The segment argument for the %d was in the string.gsub rather than string.format. I've tested it and it does work.

**Error**
![image](https://github.com/user-attachments/assets/f3fc6667-f9d3-49c5-9884-b5881aa03022)

**Code**
![image](https://github.com/user-attachments/assets/404b93a8-7f78-4e0d-8de0-f8b17b8ad29b)

**Here is it successfully writing to my DSP (addon) memory (a wav file)**
![image](https://github.com/user-attachments/assets/827aa44f-fd1d-4f66-8c57-c0b8b40dabd9)
