### PR TITLE
Fix debugger not detaching when CPU entity is removed

### DIFF
--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -589,9 +589,7 @@ if SERVER then
       end
     end
 
-    net.Start("CPULib.InvalidateDebugger")
-      net.WriteUInt(1, 2) --// 1 = detach
-    net.Send(player)
+
 
     CPULib.DebuggerData[player:UserID()] = nil
   end
@@ -610,10 +608,11 @@ if SERVER then
 
     if not IsValid(entity) or not entity.VM then return end
 
-    -- Detach any existing debugger first
+    
+    --// detach any existing debugger first
     CPULib.DetachDebugger(player)
 
-    -- Hook entity removal so debugger disables itself
+   
     if not entity._CPULibDebuggerHooked then
       entity._CPULibDebuggerHooked = true
 
@@ -625,14 +624,20 @@ if SERVER then
 
         if IsValid(player) then
           CPULib.DetachDebugger(player)
+
+          net.Start("CPULib.InvalidateDebugger")
+            net.WriteUInt(1, 2) --// 1 = detach
+          net.Send(player)
         end
       end
     end
 
     entity.BreakpointInstructions = {}
+
     entity.OnBreakpointInstruction = function(IP)
       local data = CPULib.DebuggerData[player:UserID()]
       if not data then return end
+
       CPULib.SendDebugData(entity.VM, data.MemPointers, player)
     end
 
@@ -661,6 +666,7 @@ if SERVER then
       entity.VM.BaseInterrupt = entity.VM.Interrupt
       entity.VM.Interrupt = function(VM, interruptNo, interruptParameter, isExternal, cascadeInterrupt)
         VM:BaseInterrupt(interruptNo, interruptParameter, isExternal, cascadeInterrupt)
+
         if interruptNo < 27 then
           CPULib.DebugLogInterrupt(player, interruptNo, interruptParameter, isExternal, cascadeInterrupt)
 

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -589,6 +589,10 @@ if SERVER then
       end
     end
 
+    net.Start("CPULib.InvalidateDebugger")
+      net.WriteUInt(1, 2) -- 1 = detach
+    net.Send(player)
+
     CPULib.DebuggerData[player:UserID()] = nil
   end
 

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -590,7 +590,7 @@ if SERVER then
     end
 
     net.Start("CPULib.InvalidateDebugger")
-      net.WriteUInt(1, 2) -- 1 = detach
+      net.WriteUInt(1, 2) --// 1 = detach
     net.Send(player)
 
     CPULib.DebuggerData[player:UserID()] = nil
@@ -599,50 +599,74 @@ if SERVER then
 
   ------------------------------------------------------------------------------
   -- Attach a debugger
-  function CPULib.AttachDebugger(entity,player)
-    if entity then
-      entity.BreakpointInstructions = {}
-      entity.OnBreakpointInstruction = function(IP)
-        CPULib.SendDebugData(entity.VM,CPULib.DebuggerData[player:UserID()].MemPointers,player)
-      end
-      entity.OnVMStep = function()
-        if CurTime() - CPULib.DebuggerData[player:UserID()].PreviousUpdateTime > 0.2 then
-          CPULib.DebuggerData[player:UserID()].PreviousUpdateTime = CurTime()
+  function CPULib.AttachDebugger(entity, player)
+    if not IsValid(player) then return end
 
-          -- Send a fake update that messes up line pointer, updates registers
-          local tempIP = entity.VM.IP
-          entity.VM.IP = INVALID_BREAKPOINT_IP
-          CPULib.SendDebugData(entity.VM,nil,player)
-          entity.VM.IP = tempIP
-        end
-      end
-      if not entity.VM.BaseJump then
-        entity.VM.BaseJump = entity.VM.Jump
-        entity.VM.Jump = function(VM,IP,CS)
-          VM:BaseJump(IP,CS)
-          entity.ForceLastInstruction = true
-        end
-        entity.VM.BaseInterrupt = entity.VM.Interrupt
-        entity.VM.Interrupt = function(VM,interruptNo,interruptParameter,isExternal,cascadeInterrupt)
-          VM:BaseInterrupt(interruptNo,interruptParameter,isExternal,cascadeInterrupt)
-          if interruptNo < 27 then
-            CPULib.DebugLogInterrupt(player,interruptNo,interruptParameter,isExternal,cascadeInterrupt)
-            CPULib.SendDebugData(entity.VM,CPULib.DebuggerData[player:UserID()].MemPointers,player)
-          end
-        end
-      end
-    else
-      if CPULib.DebuggerData[player:UserID()] then
-        if CPULib.DebuggerData[player:UserID()].Entity and
-           CPULib.DebuggerData[player:UserID()].Entity.VM and
-           CPULib.DebuggerData[player:UserID()].Entity.VM.BaseInterrupt then
+    -- DETACH PATH
+    if not entity then
+      CPULib.DetachDebugger(player)
+      return
+    end
 
-          CPULib.DebuggerData[player:UserID()].Entity.BreakpointInstructions = nil
-          if CPULib.DebuggerData[player:UserID()].Entity.VM.BaseJump then
-            CPULib.DebuggerData[player:UserID()].Entity.VM.Jump = CPULib.DebuggerData[player:UserID()].Entity.VM.BaseJump
-            CPULib.DebuggerData[player:UserID()].Entity.VM.Interrupt = CPULib.DebuggerData[player:UserID()].Entity.VM.BaseInterrupt
-            CPULib.DebuggerData[player:UserID()].Entity.VM.BaseJump = nil
-            CPULib.DebuggerData[player:UserID()].Entity.VM.BaseInterrupt = nil
+    if not IsValid(entity) or not entity.VM then return end
+
+    -- Detach any existing debugger first
+    CPULib.DetachDebugger(player)
+
+    -- Hook entity removal so debugger disables itself
+    if not entity._CPULibDebuggerHooked then
+      entity._CPULibDebuggerHooked = true
+
+      local oldOnRemove = entity.OnRemove
+      entity.OnRemove = function(ent)
+        if oldOnRemove then
+          oldOnRemove(ent)
+        end
+
+        if IsValid(player) then
+          CPULib.DetachDebugger(player)
+        end
+      end
+    end
+
+    entity.BreakpointInstructions = {}
+    entity.OnBreakpointInstruction = function(IP)
+      local data = CPULib.DebuggerData[player:UserID()]
+      if not data then return end
+      CPULib.SendDebugData(entity.VM, data.MemPointers, player)
+    end
+
+    entity.OnVMStep = function()
+      local data = CPULib.DebuggerData[player:UserID()]
+      if not data then return end
+
+      if CurTime() - data.PreviousUpdateTime > 0.2 then
+        data.PreviousUpdateTime = CurTime()
+
+        -- Send a fake update that messes up line pointer, updates registers
+        local tempIP = entity.VM.IP
+        entity.VM.IP = INVALID_BREAKPOINT_IP
+        CPULib.SendDebugData(entity.VM, nil, player)
+        entity.VM.IP = tempIP
+      end
+    end
+
+    if not entity.VM.BaseJump then
+      entity.VM.BaseJump = entity.VM.Jump
+      entity.VM.Jump = function(VM, IP, CS)
+        VM:BaseJump(IP, CS)
+        entity.ForceLastInstruction = true
+      end
+
+      entity.VM.BaseInterrupt = entity.VM.Interrupt
+      entity.VM.Interrupt = function(VM, interruptNo, interruptParameter, isExternal, cascadeInterrupt)
+        VM:BaseInterrupt(interruptNo, interruptParameter, isExternal, cascadeInterrupt)
+        if interruptNo < 27 then
+          CPULib.DebugLogInterrupt(player, interruptNo, interruptParameter, isExternal, cascadeInterrupt)
+
+          local data = CPULib.DebuggerData[player:UserID()]
+          if data then
+            CPULib.SendDebugData(entity.VM, data.MemPointers, player)
           end
         end
       end
@@ -655,6 +679,7 @@ if SERVER then
       PreviousUpdateTime = CurTime(),
     }
   end
+
 
   -- Log debug interrupt
   function CPULib.DebugLogInterrupt(player,interruptNo,interruptParameter,isExternal,cascadeInterrupt)

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -565,6 +565,34 @@ if SERVER then
   -- Players and corresponding entities (for the debugger)
   CPULib.DebuggerData = {}
 
+
+  ------------------------------------------------------------------------------
+  -- Detach debugger
+  function CPULib.DetachDebugger(player)
+    if not IsValid(player) then return end
+
+    local data = CPULib.DebuggerData[player:UserID()]
+    if not data then return end
+
+    local ent = data.Entity
+    if IsValid(ent) and ent.VM then
+      ent.BreakpointInstructions = nil
+
+      if ent.VM.BaseJump then
+        ent.VM.Jump = ent.VM.BaseJump
+        ent.VM.BaseJump = nil
+      end
+
+      if ent.VM.BaseInterrupt then
+        ent.VM.Interrupt = ent.VM.BaseInterrupt
+        ent.VM.BaseInterrupt = nil
+      end
+    end
+
+    CPULib.DebuggerData[player:UserID()] = nil
+  end
+
+
   ------------------------------------------------------------------------------
   -- Attach a debugger
   function CPULib.AttachDebugger(entity,player)


### PR DESCRIPTION
When a debugger is attached to a CPU entity, removing the entity does not currently detach the debugger. As a result, the debugger remains attached to a non-existent CPU, which can be confusing.

This PR ensures the debugger is properly detached when the CPU entity is removed, also creates a DetachDebugger method that removes the giant chunk of code in the original AttachDebugger method that was responsible for detaching it manually.